### PR TITLE
Fix failing pytest tests

### DIFF
--- a/src/meshcore_hub/api/auth.py
+++ b/src/meshcore_hub/api/auth.py
@@ -83,8 +83,9 @@ async def require_read(
         return token
 
     raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
+        status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid API key",
+        headers={"WWW-Authenticate": "Bearer"},
     )
 
 

--- a/src/meshcore_hub/api/routes/__init__.py
+++ b/src/meshcore_hub/api/routes/__init__.py
@@ -25,4 +25,4 @@ api_router.include_router(
 )
 api_router.include_router(telemetry_router, prefix="/telemetry", tags=["Telemetry"])
 api_router.include_router(commands_router, prefix="/commands", tags=["Commands"])
-api_router.include_router(dashboard_router, tags=["Dashboard"])
+api_router.include_router(dashboard_router, prefix="/dashboard", tags=["Dashboard"])

--- a/src/meshcore_hub/api/routes/messages.py
+++ b/src/meshcore_hub/api/routes/messages.py
@@ -18,7 +18,7 @@ router = APIRouter()
 async def list_messages(
     _: RequireRead,
     session: DbSession,
-    type: Optional[str] = Query(None, description="Filter by message type"),
+    message_type: Optional[str] = Query(None, description="Filter by message type"),
     pubkey_prefix: Optional[str] = Query(None, description="Filter by sender prefix"),
     channel_idx: Optional[int] = Query(None, description="Filter by channel"),
     since: Optional[datetime] = Query(None, description="Start timestamp"),
@@ -31,8 +31,8 @@ async def list_messages(
     # Build query
     query = select(Message)
 
-    if type:
-        query = query.where(Message.message_type == type)
+    if message_type:
+        query = query.where(Message.message_type == message_type)
 
     if pubkey_prefix:
         query = query.where(Message.pubkey_prefix == pubkey_prefix)


### PR DESCRIPTION
- Return 401 instead of 403 for invalid API keys in require_read
- Add /dashboard prefix to dashboard router so routes are at /api/v1/dashboard/*
- Rename message filter param from 'type' to 'message_type' for clarity
- Add GET /nodes/{public_key}/tags/{key} endpoint for single tag retrieval