### PR TITLE
Fix Black linting issues in CI pipeline

### DIFF
--- a/src/meshcore_hub/collector/webhook.py
+++ b/src/meshcore_hub/collector/webhook.py
@@ -404,7 +404,7 @@ _dispatch_callback: Optional[Callable[[str, dict[str, Any], Optional[str]], None
 
 
 def set_dispatch_callback(
-    callback: Optional[Callable[[str, dict[str, Any], Optional[str]], None]]
+    callback: Optional[Callable[[str, dict[str, Any], Optional[str]], None]],
 ) -> None:
     """Set a callback for synchronous webhook dispatch.
 


### PR DESCRIPTION
Black requires a trailing comma after the callback parameter when the function signature spans multiple lines.