### PR TITLE
Prepare repository for public release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ This document provides context and guidelines for AI coding assistants working o
 ## Agent Rules
 
 * You MUST use Python (version in `.python-version` file)
-* You MUST activate a Python virtual environment in the `venv` directory or create one if it does not exist:
-  - `ls ./venv` to check if it exists
+* You MUST activate a Python virtual environment in the `.venv` directory or create one if it does not exist:
+  - `ls ./.venv` to check if it exists
   - `python -m venv .venv` to create it
 * You MUST always activate the virtual environment before running any commands
   - `source .venv/bin/activate`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Docker Compose runs core services by default and uses **profiles** for optional 
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-org/meshcore-hub.git
+git clone https://github.com/ipnet-mesh/meshcore-hub.git
 cd meshcore-hub
 
 # Copy and configure environment
@@ -228,7 +228,6 @@ Webhook payload format:
 | `NETWORK_NAME` | `MeshCore Network` | Display name for the network |
 | `NETWORK_CITY` | *(none)* | City where network is located |
 | `NETWORK_COUNTRY` | *(none)* | Country code (ISO 3166-1 alpha-2) |
-| `NETWORK_LOCATION` | *(none)* | Center coordinates (lat,lon) |
 
 ## CLI Reference
 
@@ -449,7 +448,7 @@ curl -X POST \
 | GET | `/api/v1/trace-paths` | List trace paths |
 | POST | `/api/v1/commands/send-message` | Send direct message |
 | POST | `/api/v1/commands/send-channel-message` | Send channel message |
-| GET | `/api/v1/stats` | Get network statistics |
+| GET | `/api/v1/dashboard/stats` | Get network statistics |
 
 ## Development
 
@@ -457,7 +456,7 @@ curl -X POST \
 
 ```bash
 # Clone and setup
-git clone https://github.com/your-org/meshcore-hub.git
+git clone https://github.com/ipnet-mesh/meshcore-hub.git
 cd meshcore-hub
 python -m venv .venv
 source .venv/bin/activate
@@ -526,8 +525,8 @@ meshcore-hub/
 │   └── seed/               # Example seed data files
 │       ├── node_tags.yaml  # Example node tags
 │       └── members.yaml    # Example network members
-├── seed/                   # Seed data directory (SEED_HOME)
-├── data/                   # Runtime data directory (DATA_HOME, gitignored)
+├── seed/                   # Seed data directory (SEED_HOME, copy from example/seed/)
+├── data/                   # Runtime data directory (DATA_HOME, created at runtime)
 ├── Dockerfile              # Docker build configuration
 ├── docker-compose.yml      # Docker Compose services
 ├── PROMPT.md               # Project specification
@@ -557,7 +556,7 @@ meshcore-hub/
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+This project is licensed under the GNU General Public License v3.0 or later (GPL-3.0-or-later). See [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "meshcore-hub"
 version = "0.1.0"
 description = "Python monorepo for managing and orchestrating MeshCore mesh networks"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.11"
 authors = [
     {name = "MeshCore Hub Contributors"}
@@ -15,7 +15,7 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
@@ -63,10 +63,10 @@ postgres = [
 meshcore-hub = "meshcore_hub.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/meshcore-dev/meshcore-hub"
-Documentation = "https://github.com/meshcore-dev/meshcore-hub#readme"
-Repository = "https://github.com/meshcore-dev/meshcore-hub"
-Issues = "https://github.com/meshcore-dev/meshcore-hub/issues"
+Homepage = "https://github.com/ipnet-mesh/meshcore-hub"
+Documentation = "https://github.com/ipnet-mesh/meshcore-hub#readme"
+Repository = "https://github.com/ipnet-mesh/meshcore-hub"
+Issues = "https://github.com/ipnet-mesh/meshcore-hub/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
- Update license from MIT to GPL-3.0-or-later in pyproject.toml
- Update project URLs from meshcore-dev to ipnet-mesh organization
- Add explicit GPL-3.0 license statement to README
- Fix AGENTS.md venv directory reference (.venv vs venv)
- Remove undocumented NETWORK_LOCATION from README
- Fix stats endpoint path in README (/api/v1/dashboard/stats)
- Clarify seed and data directory descriptions in project structure