### PR TITLE
Added support for MQTT TLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ MQTT_USERNAME=
 MQTT_PASSWORD=
 MQTT_PREFIX=meshcore
 
+# Enable TLS/SSL for MQTT connection (default: false)
+# When enabled, uses TLS with system CA certificates (e.g., for Let's Encrypt)
+# Set to true for secure MQTT connections (port 8883)
+MQTT_TLS=false
+
 # External port mappings for local MQTT broker (--profile mqtt only)
 MQTT_EXTERNAL_PORT=1883
 MQTT_WS_PORT=9001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - MQTT_USERNAME=${MQTT_USERNAME:-}
       - MQTT_PASSWORD=${MQTT_PASSWORD:-}
       - MQTT_PREFIX=${MQTT_PREFIX:-meshcore}
+      - MQTT_TLS=${MQTT_TLS:-false}
       - SERIAL_PORT=${SERIAL_PORT:-/dev/ttyUSB0}
       - SERIAL_BAUD=${SERIAL_BAUD:-115200}
       - NODE_ADDRESS=${NODE_ADDRESS:-}
@@ -81,6 +82,7 @@ services:
       - MQTT_USERNAME=${MQTT_USERNAME:-}
       - MQTT_PASSWORD=${MQTT_PASSWORD:-}
       - MQTT_PREFIX=${MQTT_PREFIX:-meshcore}
+      - MQTT_TLS=${MQTT_TLS:-false}
       - SERIAL_PORT=${SERIAL_PORT_SENDER:-/dev/ttyUSB1}
       - SERIAL_BAUD=${SERIAL_BAUD:-115200}
       - NODE_ADDRESS=${NODE_ADDRESS_SENDER:-}
@@ -112,6 +114,7 @@ services:
       - MQTT_USERNAME=${MQTT_USERNAME:-}
       - MQTT_PASSWORD=${MQTT_PASSWORD:-}
       - MQTT_PREFIX=${MQTT_PREFIX:-meshcore}
+      - MQTT_TLS=${MQTT_TLS:-false}
       - MOCK_DEVICE=true
       - NODE_ADDRESS=${NODE_ADDRESS:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
     command: ["interface", "receiver", "--mock"]
@@ -145,6 +148,7 @@ services:
       - MQTT_USERNAME=${MQTT_USERNAME:-}
       - MQTT_PASSWORD=${MQTT_PASSWORD:-}
       - MQTT_PREFIX=${MQTT_PREFIX:-meshcore}
+      - MQTT_TLS=${MQTT_TLS:-false}
       - DATA_HOME=/data
       - SEED_HOME=/seed
       # Explicitly unset to use DATA_HOME-based default path
@@ -197,6 +201,7 @@ services:
       - MQTT_USERNAME=${MQTT_USERNAME:-}
       - MQTT_PASSWORD=${MQTT_PASSWORD:-}
       - MQTT_PREFIX=${MQTT_PREFIX:-meshcore}
+      - MQTT_TLS=${MQTT_TLS:-false}
       - DATA_HOME=/data
       # Explicitly unset to use DATA_HOME-based default path
       - DATABASE_URL=

--- a/src/meshcore_hub/api/app.py
+++ b/src/meshcore_hub/api/app.py
@@ -52,6 +52,7 @@ def create_app(
     mqtt_host: str = "localhost",
     mqtt_port: int = 1883,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
     cors_origins: list[str] | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
@@ -63,6 +64,7 @@ def create_app(
         mqtt_host: MQTT broker host
         mqtt_port: MQTT broker port
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
         cors_origins: Allowed CORS origins
 
     Returns:
@@ -85,6 +87,7 @@ def create_app(
     app.state.mqtt_host = mqtt_host
     app.state.mqtt_port = mqtt_port
     app.state.mqtt_prefix = mqtt_prefix
+    app.state.mqtt_tls = mqtt_tls
 
     # Configure CORS
     if cors_origins is None:

--- a/src/meshcore_hub/api/cli.py
+++ b/src/meshcore_hub/api/cli.py
@@ -68,6 +68,13 @@ import click
     help="MQTT topic prefix",
 )
 @click.option(
+    "--mqtt-tls",
+    is_flag=True,
+    default=False,
+    envvar="MQTT_TLS",
+    help="Enable TLS/SSL for MQTT connection",
+)
+@click.option(
     "--cors-origins",
     type=str,
     default=None,
@@ -92,6 +99,7 @@ def api(
     mqtt_host: str,
     mqtt_port: int,
     mqtt_prefix: str,
+    mqtt_tls: bool,
     cors_origins: str | None,
     reload: bool,
 ) -> None:
@@ -171,6 +179,7 @@ def api(
             mqtt_host=mqtt_host,
             mqtt_port=mqtt_port,
             mqtt_prefix=mqtt_prefix,
+            mqtt_tls=mqtt_tls,
             cors_origins=origins_list,
         )
 

--- a/src/meshcore_hub/api/dependencies.py
+++ b/src/meshcore_hub/api/dependencies.py
@@ -57,6 +57,7 @@ def get_mqtt_client(request: Request) -> MQTTClient:
     mqtt_host = getattr(request.app.state, "mqtt_host", "localhost")
     mqtt_port = getattr(request.app.state, "mqtt_port", 1883)
     mqtt_prefix = getattr(request.app.state, "mqtt_prefix", "meshcore")
+    mqtt_tls = getattr(request.app.state, "mqtt_tls", False)
 
     # Use unique client ID to allow multiple API instances
     unique_id = uuid.uuid4().hex[:8]
@@ -65,6 +66,7 @@ def get_mqtt_client(request: Request) -> MQTTClient:
         port=mqtt_port,
         prefix=mqtt_prefix,
         client_id=f"meshcore-api-{unique_id}",
+        tls=mqtt_tls,
     )
 
     client = MQTTClient(config)

--- a/src/meshcore_hub/collector/cli.py
+++ b/src/meshcore_hub/collector/cli.py
@@ -48,6 +48,13 @@ if TYPE_CHECKING:
     help="MQTT topic prefix",
 )
 @click.option(
+    "--mqtt-tls",
+    is_flag=True,
+    default=False,
+    envvar="MQTT_TLS",
+    help="Enable TLS/SSL for MQTT connection",
+)
+@click.option(
     "--data-home",
     type=str,
     default=None,
@@ -82,6 +89,7 @@ def collector(
     mqtt_username: str | None,
     mqtt_password: str | None,
     prefix: str,
+    mqtt_tls: bool,
     data_home: str | None,
     seed_home: str | None,
     database_url: str | None,
@@ -125,6 +133,7 @@ def collector(
     ctx.obj["mqtt_username"] = mqtt_username
     ctx.obj["mqtt_password"] = mqtt_password
     ctx.obj["prefix"] = prefix
+    ctx.obj["mqtt_tls"] = mqtt_tls
     ctx.obj["data_home"] = data_home or settings.data_home
     ctx.obj["seed_home"] = settings.effective_seed_home
     ctx.obj["database_url"] = effective_db_url
@@ -139,6 +148,7 @@ def collector(
             mqtt_username=mqtt_username,
             mqtt_password=mqtt_password,
             prefix=prefix,
+            mqtt_tls=mqtt_tls,
             database_url=effective_db_url,
             log_level=log_level,
             data_home=data_home or settings.data_home,
@@ -152,6 +162,7 @@ def _run_collector_service(
     mqtt_username: str | None,
     mqtt_password: str | None,
     prefix: str,
+    mqtt_tls: bool,
     database_url: str,
     log_level: str,
     data_home: str,
@@ -236,6 +247,7 @@ def _run_collector_service(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=prefix,
+        mqtt_tls=mqtt_tls,
         database_url=database_url,
         webhook_dispatcher=webhook_dispatcher,
     )
@@ -254,6 +266,7 @@ def run_cmd(ctx: click.Context) -> None:
         mqtt_username=ctx.obj["mqtt_username"],
         mqtt_password=ctx.obj["mqtt_password"],
         prefix=ctx.obj["prefix"],
+        mqtt_tls=ctx.obj["mqtt_tls"],
         database_url=ctx.obj["database_url"],
         log_level=ctx.obj["log_level"],
         data_home=ctx.obj["data_home"],

--- a/src/meshcore_hub/collector/subscriber.py
+++ b/src/meshcore_hub/collector/subscriber.py
@@ -293,6 +293,7 @@ def create_subscriber(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
     database_url: str = "sqlite:///./meshcore.db",
     webhook_dispatcher: Optional["WebhookDispatcher"] = None,
 ) -> Subscriber:
@@ -304,6 +305,7 @@ def create_subscriber(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
         database_url: Database connection URL
         webhook_dispatcher: Optional webhook dispatcher for event forwarding
 
@@ -319,6 +321,7 @@ def create_subscriber(
         password=mqtt_password,
         prefix=mqtt_prefix,
         client_id=f"meshcore-collector-{unique_id}",
+        tls=mqtt_tls,
     )
     mqtt_client = MQTTClient(mqtt_config)
 
@@ -342,6 +345,7 @@ def run_collector(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
     database_url: str = "sqlite:///./meshcore.db",
     webhook_dispatcher: Optional["WebhookDispatcher"] = None,
 ) -> None:
@@ -353,6 +357,7 @@ def run_collector(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
         database_url: Database connection URL
         webhook_dispatcher: Optional webhook dispatcher for event forwarding
     """
@@ -362,6 +367,7 @@ def run_collector(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=mqtt_prefix,
+        mqtt_tls=mqtt_tls,
         database_url=database_url,
         webhook_dispatcher=webhook_dispatcher,
     )

--- a/src/meshcore_hub/common/config.py
+++ b/src/meshcore_hub/common/config.py
@@ -52,6 +52,9 @@ class CommonSettings(BaseSettings):
         default=None, description="MQTT password (optional)"
     )
     mqtt_prefix: str = Field(default="meshcore", description="MQTT topic prefix")
+    mqtt_tls: bool = Field(
+        default=False, description="Enable TLS/SSL for MQTT connection"
+    )
 
 
 class InterfaceSettings(CommonSettings):

--- a/src/meshcore_hub/common/mqtt.py
+++ b/src/meshcore_hub/common/mqtt.py
@@ -23,6 +23,7 @@ class MQTTConfig:
     client_id: Optional[str] = None
     keepalive: int = 60
     clean_session: bool = True
+    tls: bool = False
 
 
 class TopicBuilder:
@@ -130,6 +131,11 @@ class MQTTClient:
         )
         self._connected = False
         self._message_handlers: dict[str, list[MessageHandler]] = {}
+
+        # Set up TLS if enabled
+        if config.tls:
+            self._client.tls_set()
+            logger.debug("TLS/SSL enabled for MQTT connection")
 
         # Set up authentication if provided
         if config.username:
@@ -344,6 +350,7 @@ def create_mqtt_client(
     password: Optional[str] = None,
     prefix: str = "meshcore",
     client_id: Optional[str] = None,
+    tls: bool = False,
 ) -> MQTTClient:
     """Create and configure an MQTT client.
 
@@ -354,6 +361,7 @@ def create_mqtt_client(
         password: MQTT password (optional)
         prefix: Topic prefix
         client_id: Client identifier (optional)
+        tls: Enable TLS/SSL connection (optional)
 
     Returns:
         Configured MQTTClient instance
@@ -365,5 +373,6 @@ def create_mqtt_client(
         password=password,
         prefix=prefix,
         client_id=client_id,
+        tls=tls,
     )
     return MQTTClient(config)

--- a/src/meshcore_hub/interface/cli.py
+++ b/src/meshcore_hub/interface/cli.py
@@ -94,6 +94,13 @@ def interface() -> None:
     help="MQTT topic prefix",
 )
 @click.option(
+    "--mqtt-tls",
+    is_flag=True,
+    default=False,
+    envvar="MQTT_TLS",
+    help="Enable TLS/SSL for MQTT connection",
+)
+@click.option(
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     default="INFO",
@@ -112,6 +119,7 @@ def run(
     mqtt_username: str | None,
     mqtt_password: str | None,
     prefix: str,
+    mqtt_tls: bool,
     log_level: str,
 ) -> None:
     """Run the interface component.
@@ -153,6 +161,7 @@ def run(
             mqtt_username=mqtt_username,
             mqtt_password=mqtt_password,
             mqtt_prefix=prefix,
+            mqtt_tls=mqtt_tls,
         )
     elif mode_upper == "SENDER":
         from meshcore_hub.interface.sender import run_sender
@@ -168,6 +177,7 @@ def run(
             mqtt_username=mqtt_username,
             mqtt_password=mqtt_password,
             mqtt_prefix=prefix,
+            mqtt_tls=mqtt_tls,
         )
     else:
         click.echo(f"Unknown mode: {mode}", err=True)
@@ -245,6 +255,13 @@ def run(
     envvar="MQTT_PREFIX",
     help="MQTT topic prefix",
 )
+@click.option(
+    "--mqtt-tls",
+    is_flag=True,
+    default=False,
+    envvar="MQTT_TLS",
+    help="Enable TLS/SSL for MQTT connection",
+)
 def receiver(
     port: str,
     baud: int,
@@ -256,6 +273,7 @@ def receiver(
     mqtt_username: str | None,
     mqtt_password: str | None,
     prefix: str,
+    mqtt_tls: bool,
 ) -> None:
     """Run interface in RECEIVER mode.
 
@@ -280,6 +298,7 @@ def receiver(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=prefix,
+        mqtt_tls=mqtt_tls,
     )
 
 
@@ -354,6 +373,13 @@ def receiver(
     envvar="MQTT_PREFIX",
     help="MQTT topic prefix",
 )
+@click.option(
+    "--mqtt-tls",
+    is_flag=True,
+    default=False,
+    envvar="MQTT_TLS",
+    help="Enable TLS/SSL for MQTT connection",
+)
 def sender(
     port: str,
     baud: int,
@@ -365,6 +391,7 @@ def sender(
     mqtt_username: str | None,
     mqtt_password: str | None,
     prefix: str,
+    mqtt_tls: bool,
 ) -> None:
     """Run interface in SENDER mode.
 
@@ -389,4 +416,5 @@ def sender(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=prefix,
+        mqtt_tls=mqtt_tls,
     )

--- a/src/meshcore_hub/interface/receiver.py
+++ b/src/meshcore_hub/interface/receiver.py
@@ -290,6 +290,7 @@ def create_receiver(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
 ) -> Receiver:
     """Create a configured receiver instance.
 
@@ -304,6 +305,7 @@ def create_receiver(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
 
     Returns:
         Configured Receiver instance
@@ -324,6 +326,7 @@ def create_receiver(
         password=mqtt_password,
         prefix=mqtt_prefix,
         client_id=f"meshcore-receiver-{device.public_key[:12] if device.public_key else 'unknown'}",
+        tls=mqtt_tls,
     )
     mqtt_client = MQTTClient(mqtt_config)
 
@@ -341,6 +344,7 @@ def run_receiver(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
 ) -> None:
     """Run the receiver (blocking).
 
@@ -357,6 +361,7 @@ def run_receiver(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
     """
     receiver = create_receiver(
         port=port,
@@ -369,6 +374,7 @@ def run_receiver(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=mqtt_prefix,
+        mqtt_tls=mqtt_tls,
     )
 
     # Set up signal handlers

--- a/src/meshcore_hub/interface/sender.py
+++ b/src/meshcore_hub/interface/sender.py
@@ -293,6 +293,7 @@ def create_sender(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
 ) -> Sender:
     """Create a configured sender instance.
 
@@ -307,6 +308,7 @@ def create_sender(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
 
     Returns:
         Configured Sender instance
@@ -327,6 +329,7 @@ def create_sender(
         password=mqtt_password,
         prefix=mqtt_prefix,
         client_id=f"meshcore-sender-{device.public_key[:12] if device.public_key else 'unknown'}",
+        tls=mqtt_tls,
     )
     mqtt_client = MQTTClient(mqtt_config)
 
@@ -344,6 +347,7 @@ def run_sender(
     mqtt_username: Optional[str] = None,
     mqtt_password: Optional[str] = None,
     mqtt_prefix: str = "meshcore",
+    mqtt_tls: bool = False,
 ) -> None:
     """Run the sender (blocking).
 
@@ -360,6 +364,7 @@ def run_sender(
         mqtt_username: MQTT username
         mqtt_password: MQTT password
         mqtt_prefix: MQTT topic prefix
+        mqtt_tls: Enable TLS/SSL for MQTT connection
     """
     sender = create_sender(
         port=port,
@@ -372,6 +377,7 @@ def run_sender(
         mqtt_username=mqtt_username,
         mqtt_password=mqtt_password,
         mqtt_prefix=mqtt_prefix,
+        mqtt_tls=mqtt_tls,
     )
 
     # Set up signal handlers


### PR DESCRIPTION
This pull request adds support for enabling TLS/SSL connections to the MQTT broker throughout the project. It introduces a new `MQTT_TLS` configuration option, updates environment variables, Docker Compose, and CLI interfaces, and propagates the new option through the application's configuration and MQTT client setup. This allows secure MQTT connections (e.g., using port 8883 and Let's Encrypt certificates) by simply toggling the `MQTT_TLS` flag.

**Configuration and Environment Variable Updates:**

* Added a new `MQTT_TLS` option to `.env.example` with documentation, allowing users to enable TLS/SSL for MQTT connections via environment variables.
* Updated all relevant services in `docker-compose.yml` to include the `MQTT_TLS` environment variable, defaulting to `false`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R50) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R85) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R117) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R151) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R204)
* Extended the `CommonSettings` class in `config.py` to include the `mqtt_tls` field for centralized configuration.

**CLI and Application Interface Changes:**

* Added `--mqtt-tls` CLI option (and corresponding environment variable support) to all CLI entry points (`api`, `collector`, `interface`), and propagated the option through command signatures and context objects. [[1]](diffhunk://#diff-80eebdf114b15d8ece1afb00ec0d79b5f3d3482622e073659e29498973b32a1eR70-R76) [[2]](diffhunk://#diff-80eebdf114b15d8ece1afb00ec0d79b5f3d3482622e073659e29498973b32a1eR102) [[3]](diffhunk://#diff-80eebdf114b15d8ece1afb00ec0d79b5f3d3482622e073659e29498973b32a1eR182) [[4]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R50-R56) [[5]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R92) [[6]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R136) [[7]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R151) [[8]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R165) [[9]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R250) [[10]](diffhunk://#diff-785b6b7ed03b4733226f657ba2f2026c20dc81175493f8942ed9adc3e41458a9R269) [[11]](diffhunk://#diff-e72f7663b12b8b3ba1e7681ac291a34bb6fff726be0b3e7c90a2486845d3f77cR96-R102) [[12]](diffhunk://#diff-e72f7663b12b8b3ba1e7681ac291a34bb6fff726be0b3e7c90a2486845d3f77cR122) [[13]](diffhunk://#diff-e72f7663b12b8b3ba1e7681ac291a34bb6fff726be0b3e7c90a2486845d3f77cR164) [[14]](diffhunk://#diff-e72f7663b12b8b3ba1e7681ac291a34bb6fff726be0b3e7c90a2486845d3f77cR180) [[15]](diffhunk://#diff-e72f7663b12b8b3ba1e7681ac291a34bb6fff726be0b3e7c90a2486845d3f77cR258-R264)
* Updated the `create_app` function and related FastAPI state to accept and store the `mqtt_tls` parameter. [[1]](diffhunk://#diff-f2eb62a22f42ea0a790e429d525cc49dab0e7520f7abd26ff85c0b2a81afd85dR55) [[2]](diffhunk://#diff-f2eb62a22f42ea0a790e429d525cc49dab0e7520f7abd26ff85c0b2a81afd85dR67) [[3]](diffhunk://#diff-f2eb62a22f42ea0a790e429d525cc49dab0e7520f7abd26ff85c0b2a81afd85dR90)
* Ensured the `mqtt_tls` setting is passed through all layers, including dependency injection for MQTT clients. [[1]](diffhunk://#diff-2c3e9b8cbab5ef6aced9c0c792502aab73a9c7dd319b56ef6ec58a299cea1610R60) [[2]](diffhunk://#diff-2c3e9b8cbab5ef6aced9c0c792502aab73a9c7dd319b56ef6ec58a299cea1610R69)

**MQTT Client and Subscriber Enhancements:**

* Extended the `MQTTConfig` and `create_mqtt_client` to accept a `tls` parameter, and updated the `MQTTClient` to enable TLS/SSL if requested. [[1]](diffhunk://#diff-1620af0462be5f5db8505f74e25aeedf60e52aadbf83d3b2d1437aaeadc95359R26) [[2]](diffhunk://#diff-1620af0462be5f5db8505f74e25aeedf60e52aadbf83d3b2d1437aaeadc95359R135-R139) [[3]](diffhunk://#diff-1620af0462be5f5db8505f74e25aeedf60e52aadbf83d3b2d1437aaeadc95359R353) [[4]](diffhunk://#diff-1620af0462be5f5db8505f74e25aeedf60e52aadbf83d3b2d1437aaeadc95359R364) [[5]](diffhunk://#diff-1620af0462be5f5db8505f74e25aeedf60e52aadbf83d3b2d1437aaeadc95359R376)
* Updated all subscriber and collector creation functions to accept and pass the `mqtt_tls` flag, ensuring secure connections are used when requested. [[1]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR296) [[2]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR308) [[3]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR324) [[4]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR348) [[5]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR360) [[6]](diffhunk://#diff-84a08ef0c30b534df956dd0dd45c64ca4a0df6e155e919ef0583e4b65a50f94aR370)

These changes collectively make it easy to enable secure MQTT communication across all components of the project by setting a single flag.