### PR TITLE
Fixed version display

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,13 +59,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || format('0.0.0.dev0+g{0}', github.sha) }}
+            BUILD_VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Test Docker image
         if: github.event_name == 'pull_request'
         run: |
-          docker build -t meshcore-hub-test --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0.dev0+g${{ github.sha }} -f Dockerfile .
+          docker build -t meshcore-hub-test --build-arg BUILD_VERSION=${{ github.ref_name }} -f Dockerfile .
           docker run --rm meshcore-hub-test --version
           docker run --rm meshcore-hub-test --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Build argument for version (set via CI or manually)
-ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+docker
-
 # Copy project files
 WORKDIR /app
 COPY pyproject.toml README.md ./
@@ -31,9 +28,13 @@ COPY src/ ./src/
 COPY alembic/ ./alembic/
 COPY alembic.ini ./
 
-# Install the package with version from build arg
-RUN pip install --upgrade pip && \
-    SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION} pip install .
+# Build argument for version (set via CI or manually)
+ARG BUILD_VERSION=dev
+
+# Set version in _version.py and install the package
+RUN sed -i "s/__version__ = \"dev\"/__version__ = \"${BUILD_VERSION}\"/" src/meshcore_hub/_version.py && \
+    pip install --upgrade pip && \
+    pip install .
 
 # =============================================================================
 # Stage 2: Runtime - Final production image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel", "setuptools-scm>=8.0"]
+requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshcore-hub"
-dynamic = ["version"]
+version = "0.0.0"
 description = "Python monorepo for managing and orchestrating MeshCore mesh networks"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}
@@ -67,10 +67,6 @@ Homepage = "https://github.com/ipnet-mesh/meshcore-hub"
 Documentation = "https://github.com/ipnet-mesh/meshcore-hub#readme"
 Repository = "https://github.com/ipnet-mesh/meshcore-hub"
 Issues = "https://github.com/ipnet-mesh/meshcore-hub/issues"
-
-[tool.setuptools_scm]
-version_file = "src/meshcore_hub/_version.py"
-fallback_version = "0.0.0+unknown"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/meshcore_hub/__init__.py
+++ b/src/meshcore_hub/__init__.py
@@ -1,5 +1,5 @@
 """MeshCore Hub - Python monorepo for managing MeshCore mesh networks."""
 
-from meshcore_hub._version import __version__, __version_tuple__
+from meshcore_hub._version import __version__
 
-__all__ = ["__version__", "__version_tuple__"]
+__all__ = ["__version__"]

--- a/src/meshcore_hub/web/templates/base.html
+++ b/src/meshcore_hub/web/templates/base.html
@@ -83,7 +83,7 @@
             </ul>
         </div>
         <div class="navbar-end">
-            <div class="badge badge-outline badge-sm">v{{ version }}</div>
+            <div class="badge badge-outline badge-sm">{{ version }}</div>
         </div>
     </div>
 
@@ -114,7 +114,7 @@
                 <a href="{{ network_contact_github }}" target="_blank" rel="noopener noreferrer" class="link link-hover">GitHub</a>
                 {% endif %}
             </p>
-            <p class="text-xs opacity-50 mt-2">Powered by <a href="https://github.com/ipnet-mesh/meshcore-hub" target="_blank" rel="noopener noreferrer" class="link link-hover">MeshCore Hub</a> v{{ version }}</p>
+            <p class="text-xs opacity-50 mt-2">Powered by <a href="https://github.com/ipnet-mesh/meshcore-hub" target="_blank" rel="noopener noreferrer" class="link link-hover">MeshCore Hub</a> {{ version }}</p>
         </aside>
     </footer>
 


### PR DESCRIPTION
This pull request refactors the way the project version is managed and injected throughout the build and runtime process. The changes remove the dependency on `setuptools-scm` for dynamic versioning, and instead use a build argument (`BUILD_VERSION`) to set the version directly in the source code and Docker image. This simplifies version management and ensures the version is consistently available in the application and its UI.

**Versioning and Build Process:**

* Switched from `setuptools-scm` dynamic versioning to a static version field in `pyproject.toml`, removing the `[tool.setuptools_scm]` section and related dependencies. (`pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L71-L74)
* Updated Docker build workflow and `Dockerfile` to use a `BUILD_VERSION` argument, which is injected into `src/meshcore_hub/_version.py` during build, ensuring the application version matches the build context. (`.github/workflows/docker.yml`, `Dockerfile`) [[1]](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94L62-R69) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L24-R37)

**Codebase and API Cleanup:**

* Removed `__version_tuple__` from `src/meshcore_hub/__init__.py`, leaving only `__version__` as the public version identifier.

**User Interface Consistency:**

* Updated version display in `base.html` templates to remove the "v" prefix and ensure the correct version is shown in both the navbar and footer. (`src/meshcore_hub/web/templates/base.html`) [[1]](diffhunk://#diff-a6be77727069203d2d58b886baa7e2a20ad072614e3fa777bf80236c368bc7baL86-R86) [[2]](diffhunk://#diff-a6be77727069203d2d58b886baa7e2a20ad072614e3fa777bf80236c368bc7baL117-R117)