### PR TITLE
Receiver nodes now sync contacts to MQTT on every advert received

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -624,6 +624,20 @@ On startup, the receiver performs these initialization steps:
 1. Set device clock to current Unix timestamp
 2. Send a local (non-flood) advertisement
 3. Start automatic message fetching
+4. Sync the device's contact database
+
+### Contact Sync Behavior
+
+The receiver syncs the device's contact database in two scenarios:
+
+1. **Startup**: Initial sync when receiver starts
+2. **Advertisement Events**: Automatic sync triggered whenever an advertisement is received from the mesh
+
+Since advertisements are typically received every ~20 minutes, contact sync happens automatically without manual intervention. Each contact from the device is published individually to MQTT:
+- Topic: `{prefix}/{device_public_key}/event/contact`
+- Payload: `{public_key, adv_name, type}`
+
+This ensures the collector's database stays current with all nodes discovered on the mesh network.
 
 ## References
 

--- a/src/meshcore_hub/interface/mock_device.py
+++ b/src/meshcore_hub/interface/mock_device.py
@@ -292,7 +292,10 @@ class MockMeshCoreDevice(BaseMeshCoreDevice):
         return True
 
     def get_contacts(self) -> bool:
-        """Fetch contacts from mock device contact database."""
+        """Fetch contacts from mock device contact database.
+
+        Note: This should only be called before the event loop is running.
+        """
         if not self._connected:
             logger.error("Cannot get contacts: not connected")
             return False
@@ -317,6 +320,14 @@ class MockMeshCoreDevice(BaseMeshCoreDevice):
 
         threading.Thread(target=send_contacts, daemon=True).start()
         return True
+
+    def schedule_get_contacts(self) -> bool:
+        """Schedule a get_contacts request.
+
+        For the mock device, this is the same as get_contacts() since we
+        don't have a real async event loop. The contacts are sent via a thread.
+        """
+        return self.get_contacts()
 
     def run(self) -> None:
         """Run the mock device event loop."""

--- a/src/meshcore_hub/interface/receiver.py
+++ b/src/meshcore_hub/interface/receiver.py
@@ -144,8 +144,23 @@ class Receiver:
 
             logger.debug(f"Published {event_name} event to MQTT")
 
+            # Trigger contact sync on advertisements
+            if event_type == EventType.ADVERTISEMENT:
+                self._sync_contacts()
+
         except Exception as e:
             logger.error(f"Failed to publish event to MQTT: {e}")
+
+    def _sync_contacts(self) -> None:
+        """Request contact sync from device.
+
+        Called when advertisements are received to ensure contact database
+        stays current with all nodes on the mesh.
+        """
+        logger.info("Advertisement received, triggering contact sync")
+        success = self.device.schedule_get_contacts()
+        if not success:
+            logger.warning("Contact sync request failed")
 
     def _publish_contacts(self, payload: dict[str, Any]) -> None:
         """Publish each contact as a separate MQTT message.

--- a/tests/test_interface/test_receiver.py
+++ b/tests/test_interface/test_receiver.py
@@ -62,6 +62,56 @@ class TestReceiver:
         # Verify MQTT publish was called
         mock_mqtt_client.publish_event.assert_called()
 
+    def test_receiver_syncs_contacts_on_advertisement(
+        self, receiver, mock_device, mock_mqtt_client
+    ):
+        """Test that receiver syncs contacts when advertisement is received."""
+        import time
+        from unittest.mock import patch
+
+        receiver.start()
+
+        # Patch schedule_get_contacts to track calls
+        with patch.object(
+            mock_device, "schedule_get_contacts", return_value=True
+        ) as mock_get:
+            # Inject an advertisement event
+            mock_device.inject_event(
+                EventType.ADVERTISEMENT,
+                {"pubkey_prefix": "b" * 64, "adv_name": "TestNode", "type": 1},
+            )
+
+            # Allow time for event processing
+            time.sleep(0.1)
+
+            # Verify schedule_get_contacts was called
+            mock_get.assert_called()
+
+    def test_receiver_handles_contact_sync_failure(
+        self, receiver, mock_device, mock_mqtt_client
+    ):
+        """Test that receiver handles contact sync failures gracefully."""
+        import time
+        from unittest.mock import patch
+
+        receiver.start()
+
+        # Patch schedule_get_contacts to return False (failure)
+        with patch.object(
+            mock_device, "schedule_get_contacts", return_value=False
+        ) as mock_get:
+            # Should not raise exception even if sync fails
+            mock_device.inject_event(
+                EventType.ADVERTISEMENT,
+                {"pubkey_prefix": "c" * 64, "adv_name": "FailNode", "type": 1},
+            )
+
+            # Allow time for event processing
+            time.sleep(0.1)
+
+            # Verify it was attempted
+            mock_get.assert_called()
+
 
 class TestCreateReceiver:
     """Tests for create_receiver factory function."""


### PR DESCRIPTION
This pull request introduces automatic contact database synchronization in the mesh network receiver, ensuring the collector's database is always up-to-date with discovered nodes. The main changes include triggering contact sync on startup and upon receiving mesh advertisements, adding a safe method for scheduling contact sync during event processing, and updating documentation and tests to reflect this new behavior.

**Contact synchronization enhancements:**

* The receiver now syncs the device's contact database both at startup and automatically whenever an advertisement event is received, keeping the collector's database current with all mesh nodes. (`AGENTS.md`)
* Added a new `schedule_get_contacts` method to the device interface, allowing contact sync requests to be safely scheduled during event loop execution. This is used instead of `get_contacts` during event processing. (`src/meshcore_hub/interface/device.py`, `src/meshcore_hub/interface/mock_device.py`) [[1]](diffhunk://#diff-8f7937166790c16ac56a742a3995f6c31797d129057bcc63d2ee81e1fb91812aR196-R213) [[2]](diffhunk://#diff-8f7937166790c16ac56a742a3995f6c31797d129057bcc63d2ee81e1fb91812aL570-R588) [[3]](diffhunk://#diff-8f7937166790c16ac56a742a3995f6c31797d129057bcc63d2ee81e1fb91812aR605-R629) [[4]](diffhunk://#diff-2c75d62fcfc63a957665eda18f7d2d7645c16822a011590d1d19b414378f6283L295-R298) [[5]](diffhunk://#diff-2c75d62fcfc63a957665eda18f7d2d7645c16822a011590d1d19b414378f6283R324-R331)

**Receiver logic improvements:**

* The receiver now triggers contact sync automatically on every advertisement event, ensuring contacts are always refreshed as new nodes are discovered. (`src/meshcore_hub/interface/receiver.py`)

**Testing and documentation:**

* Added tests to verify that contact sync is triggered on advertisement events and that failures are handled gracefully. (`tests/test_interface/test_receiver.py`)
* Updated documentation to describe the new contact sync behavior and MQTT publishing details. (`AGENTS.md`)