### PR TITLE
Ensure SQLite database path/subdirectories exist before initialising …

### DIFF
--- a/src/meshcore_hub/common/database.py
+++ b/src/meshcore_hub/common/database.py
@@ -98,6 +98,15 @@ class DatabaseManager:
             echo: Enable SQL query logging
         """
         self.database_url = database_url
+
+        # Ensure parent directory exists for SQLite databases
+        if database_url.startswith("sqlite:///"):
+            from pathlib import Path
+
+            # Extract path from sqlite:///path/to/db.sqlite
+            db_path = Path(database_url.replace("sqlite:///", ""))
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+
         self.engine = create_database_engine(database_url, echo=echo)
         self.session_factory = create_session_factory(self.engine)
 


### PR DESCRIPTION
This pull request introduces a small but important improvement to the database initialization logic. Now, when using a SQLite database, the code ensures that the parent directory for the database file exists before attempting to connect. This prevents errors when the directory hasn't been created yet.

Database initialization improvements:
* In `src/meshcore_hub/common/database.py`, the `__init__` method now checks if the `database_url` uses SQLite and automatically creates the parent directory for the database file if it doesn't exist.…database