### PR TITLE
Message Filter and Table Tidying

### DIFF
--- a/src/meshcore_hub/web/routes/messages.py
+++ b/src/meshcore_hub/web/routes/messages.py
@@ -15,7 +15,6 @@ router = APIRouter()
 async def messages_list(
     request: Request,
     message_type: str | None = Query(None, description="Filter by message type"),
-    channel_idx: str | None = Query(None, description="Filter by channel"),
     search: str | None = Query(None, description="Search in message text"),
     page: int = Query(1, ge=1, description="Page number"),
     limit: int = Query(50, ge=1, le=100, description="Items per page"),
@@ -28,20 +27,10 @@ async def messages_list(
     # Calculate offset
     offset = (page - 1) * limit
 
-    # Parse channel_idx, treating empty string as None
-    channel_idx_int: int | None = None
-    if channel_idx and channel_idx.strip():
-        try:
-            channel_idx_int = int(channel_idx)
-        except ValueError:
-            logger.warning(f"Invalid channel_idx value: {channel_idx}")
-
     # Build query params
     params: dict[str, int | str] = {"limit": limit, "offset": offset}
     if message_type:
         params["message_type"] = message_type
-    if channel_idx_int is not None:
-        params["channel_idx"] = channel_idx_int
 
     # Fetch messages from API
     messages = []
@@ -70,7 +59,6 @@ async def messages_list(
             "limit": limit,
             "total_pages": total_pages,
             "message_type": message_type or "",
-            "channel_idx": channel_idx_int,
             "search": search or "",
         }
     )

--- a/src/meshcore_hub/web/templates/messages.html
+++ b/src/meshcore_hub/web/templates/messages.html
@@ -28,19 +28,8 @@
                 </label>
                 <select name="message_type" class="select select-bordered select-sm">
                     <option value="">All Types</option>
-                    <option value="direct" {% if message_type == 'direct' %}selected{% endif %}>Direct</option>
+                    <option value="contact" {% if message_type == 'contact' %}selected{% endif %}>Direct</option>
                     <option value="channel" {% if message_type == 'channel' %}selected{% endif %}>Channel</option>
-                </select>
-            </div>
-            <div class="form-control">
-                <label class="label py-1">
-                    <span class="label-text">Channel</span>
-                </label>
-                <select name="channel_idx" class="select select-bordered select-sm">
-                    <option value="">All Channels</option>
-                    {% for i in range(8) %}
-                    <option value="{{ i }}" {% if channel_idx == i %}selected{% endif %}>Channel {{ i }}</option>
-                    {% endfor %}
                 </select>
             </div>
             <div class="flex gap-2 w-full sm:w-auto">
@@ -64,7 +53,7 @@
                     <div class="min-w-0">
                         <div class="font-medium text-sm truncate">
                             {% if msg.message_type == 'channel' %}
-                            <span class="font-mono">CH{{ msg.channel_idx }}</span>
+                            <span class="opacity-60">Public</span>
                             {% else %}
                                 {% if msg.sender_tag_name or msg.sender_name %}
                                 {{ msg.sender_tag_name or msg.sender_name }}
@@ -105,7 +94,7 @@
             <tr>
                 <th>Type</th>
                 <th>Time</th>
-                <th>From/Channel</th>
+                <th>From</th>
                 <th>Message</th>
                 <th>Receivers</th>
             </tr>
@@ -121,7 +110,7 @@
                 </td>
                 <td class="text-sm whitespace-nowrap">
                     {% if msg.message_type == 'channel' %}
-                    <span class="font-mono">CH{{ msg.channel_idx }}</span>
+                    <span class="opacity-60">Public</span>
                     {% else %}
                         {% if msg.sender_tag_name or msg.sender_name %}
                         <span class="font-medium">{{ msg.sender_tag_name or msg.sender_name }}</span>
@@ -154,5 +143,5 @@
     </table>
 </div>
 
-{{ pagination(page, total_pages, {"message_type": message_type, "channel_idx": channel_idx, "limit": limit}) }}
+{{ pagination(page, total_pages, {"message_type": message_type, "limit": limit}) }}
 {% endblock %}


### PR DESCRIPTION
…lues
This pull request removes the ability to filter messages by channel in both the backend and frontend, and simplifies how channel messages are displayed in the UI. The changes streamline the messages interface by focusing on message type and removing channel-specific filtering and display options.

Backend changes:

* Removed the `channel_idx` query parameter and all related logic from the `messages_list` endpoint in `messages.py`. This includes parsing, validation, and passing of the parameter to the API. [[1]](diffhunk://#diff-d682d550ad0593694e9bb41297bb635661c8ac897c69b4850668f691d7b38a1bL18) [[2]](diffhunk://#diff-d682d550ad0593694e9bb41297bb635661c8ac897c69b4850668f691d7b38a1bL31-L44) [[3]](diffhunk://#diff-d682d550ad0593694e9bb41297bb635661c8ac897c69b4850668f691d7b38a1bL73)

Frontend/UI changes:

* Removed the channel filter dropdown from the messages filter form in `messages.html`, so users can no longer filter messages by channel.
* Updated the display of channel messages: instead of showing the channel index (e.g., `CH0`), channel messages are now labeled as "Public" in a muted style in the message list and table. [[1]](diffhunk://#diff-b00d01a41d855889d898c8b42ff49dcbd6cbd6df10dd565339dac7ef5d65a261L67-R56) [[2]](diffhunk://#diff-b00d01a41d855889d898c8b42ff49dcbd6cbd6df10dd565339dac7ef5d65a261L124-R113)
* Changed the table header from "From/Channel" to just "From" to reflect the removal of explicit channel display.
* Updated pagination to remove the `channel_idx` parameter from the query string.