### PR TITLE
Add timezone support for web dashboard date/time display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,7 @@ Key variables:
 - `MQTT_TLS` - Enable TLS/SSL for MQTT (default: `false`)
 - `API_READ_KEY`, `API_ADMIN_KEY` - API authentication keys
 - `WEB_ADMIN_ENABLED` - Enable admin interface at /a/ (default: `false`, requires auth proxy)
+- `TZ` - Timezone for web dashboard date/time display (default: `UTC`, e.g., `America/New_York`, `Europe/London`)
 - `LOG_LEVEL` - Logging verbosity
 
 The database defaults to `sqlite:///{DATA_HOME}/collector/meshcore.db` and does not typically need to be configured.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ The collector automatically cleans up old event data and inactive nodes:
 | `WEB_PORT` | `8080` | Web server port |
 | `API_BASE_URL` | `http://localhost:8000` | API endpoint URL |
 | `WEB_ADMIN_ENABLED` | `false` | Enable admin interface at /a/ (requires auth proxy) |
+| `TZ` | `UTC` | Timezone for displaying dates/times (e.g., `America/New_York`, `Europe/London`) |
 | `NETWORK_NAME` | `MeshCore Network` | Display name for the network |
 | `NETWORK_CITY` | *(none)* | City where network is located |
 | `NETWORK_COUNTRY` | *(none)* | Country code (ISO 3166-1 alpha-2) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -262,6 +262,7 @@ services:
       - NETWORK_CONTACT_YOUTUBE=${NETWORK_CONTACT_YOUTUBE:-}
       - NETWORK_WELCOME_TEXT=${NETWORK_WELCOME_TEXT:-}
       - CONTENT_HOME=/content
+      - TZ=${TZ:-UTC}
     command: ["web"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]

--- a/src/meshcore_hub/common/config.py
+++ b/src/meshcore_hub/common/config.py
@@ -253,6 +253,9 @@ class WebSettings(CommonSettings):
     web_host: str = Field(default="0.0.0.0", description="Web server host")
     web_port: int = Field(default=8080, description="Web server port")
 
+    # Timezone for date/time display (uses standard TZ environment variable)
+    tz: str = Field(default="UTC", description="Timezone for displaying dates/times")
+
     # Admin interface (disabled by default for security)
     web_admin_enabled: bool = Field(
         default=False,

--- a/src/meshcore_hub/web/templates/admin/node_tags.html
+++ b/src/meshcore_hub/web/templates/admin/node_tags.html
@@ -104,7 +104,7 @@
                         <td>
                             <span class="badge badge-ghost badge-sm">{{ tag.value_type }}</span>
                         </td>
-                        <td class="text-sm opacity-70">{{ tag.updated_at[:10] if tag.updated_at else '-' }}</td>
+                        <td class="text-sm opacity-70">{{ tag.updated_at|localdate }}</td>
                         <td>
                             <div class="flex gap-1">
                                 <button class="btn btn-ghost btn-xs btn-edit">

--- a/src/meshcore_hub/web/templates/advertisements.html
+++ b/src/meshcore_hub/web/templates/advertisements.html
@@ -86,7 +86,7 @@
                 </div>
                 <div class="text-right flex-shrink-0">
                     <div class="text-xs opacity-60">
-                        {{ ad.received_at[:16].replace('T', ' ') if ad.received_at else '-' }}
+                        {{ ad.received_at|localtime_short }}
                     </div>
                     {% if ad.receivers and ad.receivers|length >= 1 %}
                     <div class="flex gap-0.5 justify-end mt-1">
@@ -133,7 +133,7 @@
                     </a>
                 </td>
                 <td class="text-sm whitespace-nowrap">
-                    {{ ad.received_at[:19].replace('T', ' ') if ad.received_at else '-' }}
+                    {{ ad.received_at|localtime }}
                 </td>
                 <td>
                     {% if ad.receivers and ad.receivers|length >= 1 %}

--- a/src/meshcore_hub/web/templates/dashboard.html
+++ b/src/meshcore_hub/web/templates/dashboard.html
@@ -136,7 +136,7 @@
                                 <span class="opacity-50">-</span>
                                 {% endif %}
                             </td>
-                            <td class="text-right text-sm opacity-70">{{ ad.received_at.split('T')[1][:8] if ad.received_at else '-' }}</td>
+                            <td class="text-right text-sm opacity-70">{{ ad.received_at|localtimeonly }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
@@ -166,7 +166,7 @@
                     <div class="space-y-1 pl-2 border-l-2 border-base-300">
                         {% for msg in messages %}
                         <div class="text-sm">
-                            <span class="text-xs opacity-50">{{ msg.received_at.split('T')[1][:5] if msg.received_at else '' }}</span>
+                            <span class="text-xs opacity-50">{{ msg.received_at|localtimeonly_short }}</span>
                             <span class="break-words" style="white-space: pre-wrap;">{{ msg.text }}</span>
                         </div>
                         {% endfor %}

--- a/src/meshcore_hub/web/templates/members.html
+++ b/src/meshcore_hub/web/templates/members.html
@@ -60,7 +60,7 @@
                             {% endif %}
                         </div>
                         {% if node.last_seen %}
-                        <time class="text-xs opacity-60 whitespace-nowrap" datetime="{{ node.last_seen }}" title="{{ node.last_seen[:19].replace('T', ' ') }}" data-relative-time>-</time>
+                        <time class="text-xs opacity-60 whitespace-nowrap" datetime="{{ node.last_seen }}" title="{{ node.last_seen|localtime }}" data-relative-time>-</time>
                         {% endif %}
                     </a>
                     {% endfor %}

--- a/src/meshcore_hub/web/templates/messages.html
+++ b/src/meshcore_hub/web/templates/messages.html
@@ -62,7 +62,7 @@
                             {% endif %}
                         </div>
                         <div class="text-xs opacity-60">
-                            {{ msg.received_at[:16].replace('T', ' ') if msg.received_at else '-' }}
+                            {{ msg.received_at|localtime_short }}
                         </div>
                     </div>
                 </div>
@@ -105,7 +105,7 @@
                     {% if msg.message_type == 'channel' %}📻{% else %}👤{% endif %}
                 </td>
                 <td class="text-sm whitespace-nowrap">
-                    {{ msg.received_at[:19].replace('T', ' ') if msg.received_at else '-' }}
+                    {{ msg.received_at|localtime }}
                 </td>
                 <td class="text-sm whitespace-nowrap">
                     {% if msg.message_type == 'channel' %}

--- a/src/meshcore_hub/web/templates/node_detail.html
+++ b/src/meshcore_hub/web/templates/node_detail.html
@@ -108,11 +108,11 @@
         <div class="flex flex-wrap gap-x-8 gap-y-2 mt-4 text-sm">
             <div>
                 <span class="opacity-70">First seen:</span>
-                {{ node.first_seen[:19].replace('T', ' ') if node.first_seen else '-' }}
+                {{ node.first_seen|localtime }}
             </div>
             <div>
                 <span class="opacity-70">Last seen:</span>
-                {{ node.last_seen[:19].replace('T', ' ') if node.last_seen else '-' }}
+                {{ node.last_seen|localtime }}
             </div>
             {% if has_coords %}
             <div>
@@ -142,7 +142,7 @@
                     <tbody>
                         {% for adv in advertisements %}
                         <tr>
-                            <td class="text-xs whitespace-nowrap">{{ adv.received_at[:19].replace('T', ' ') if adv.received_at else '-' }}</td>
+                            <td class="text-xs whitespace-nowrap">{{ adv.received_at|localtime }}</td>
                             <td>
                                 {% if adv.adv_type and adv.adv_type|lower == 'chat' %}
                                 <span title="Chat">💬</span>

--- a/src/meshcore_hub/web/templates/nodes.html
+++ b/src/meshcore_hub/web/templates/nodes.html
@@ -85,7 +85,7 @@
                 <div class="text-right flex-shrink-0">
                     <div class="text-xs opacity-60">
                         {% if node.last_seen %}
-                        {{ node.last_seen[:10] }}
+                        {{ node.last_seen|localdate }}
                         {% else %}
                         -
                         {% endif %}
@@ -143,7 +143,7 @@
                 </td>
                 <td class="text-sm whitespace-nowrap">
                     {% if node.last_seen %}
-                    {{ node.last_seen[:19].replace('T', ' ') }}
+                    {{ node.last_seen|localtime }}
                     {% else %}
                     -
                     {% endif %}


### PR DESCRIPTION
- Add TZ environment variable support (standard Linux timezone)
- Create Jinja2 filters for timezone-aware formatting (localtime, localdate, etc.)
- Update all templates to use timezone filters with abbreviation suffix
- Pass TZ through docker-compose for web service
- Document TZ setting in README and AGENTS.md

Timestamps remain stored as UTC; only display is converted.