### PR TITLE
Enforce authentication for admin API proxy mutations

### DIFF
--- a/src/meshcore_hub/web/static/js/spa/pages/admin/index.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/admin/index.js
@@ -17,6 +17,17 @@ export async function render(container, params, router) {
             return;
         }
 
+        if (!config.is_authenticated) {
+            litRender(html`
+<div class="flex flex-col items-center justify-center py-20">
+    ${iconLock('h-16 w-16 opacity-30 mb-4')}
+    <h1 class="text-3xl font-bold mb-2">Authentication Required</h1>
+    <p class="opacity-70">You must sign in to access the admin interface.</p>
+    <a href="/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}" class="btn btn-primary mt-6">Sign In</a>
+</div>`, container);
+            return;
+        }
+
         litRender(html`
 <div class="flex items-center justify-between mb-4">
     <div>

--- a/src/meshcore_hub/web/static/js/spa/pages/admin/members.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/admin/members.js
@@ -20,6 +20,17 @@ export async function render(container, params, router) {
             return;
         }
 
+        if (!config.is_authenticated) {
+            litRender(html`
+<div class="flex flex-col items-center justify-center py-20">
+    ${iconLock('h-16 w-16 opacity-30 mb-4')}
+    <h1 class="text-3xl font-bold mb-2">Authentication Required</h1>
+    <p class="opacity-70">You must sign in to access the admin interface.</p>
+    <a href="/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}" class="btn btn-primary mt-6">Sign In</a>
+</div>`, container);
+            return;
+        }
+
         const flashMessage = (params.query && params.query.message) || '';
         const flashError = (params.query && params.query.error) || '';
 

--- a/src/meshcore_hub/web/static/js/spa/pages/admin/node-tags.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/admin/node-tags.js
@@ -21,6 +21,17 @@ export async function render(container, params, router) {
             return;
         }
 
+        if (!config.is_authenticated) {
+            litRender(html`
+<div class="flex flex-col items-center justify-center py-20">
+    ${iconLock('h-16 w-16 opacity-30 mb-4')}
+    <h1 class="text-3xl font-bold mb-2">Authentication Required</h1>
+    <p class="opacity-70">You must sign in to access the admin interface.</p>
+    <a href="/oauth2/start?rd=${encodeURIComponent(window.location.pathname)}" class="btn btn-primary mt-6">Sign In</a>
+</div>`, container);
+            return;
+        }
+
         const selectedPublicKey = (params.query && params.query.public_key) || '';
         const flashMessage = (params.query && params.query.message) || '';
         const flashError = (params.query && params.query.error) || '';


### PR DESCRIPTION
## Summary
Add server-side authentication enforcement for mutating API requests (POST, PUT, DELETE, PATCH) through the admin API proxy when admin mode is enabled. This prevents unauthenticated users from bypassing OAuth2 authentication to perform admin operations.

## Changes
- **Backend authentication check**: Added validation in `api_proxy()` to reject mutating requests without the `X-Forwarded-User` header (set by OAuth2Proxy) when admin is enabled. Returns 401 Unauthorized with a clear error message.
- **Frontend authentication guards**: Added authentication checks in admin pages (index, members, node-tags) that display a sign-in prompt when `config.is_authenticated` is false, improving UX before requests are made.
- **Test infrastructure improvements**: 
  - Enhanced mock HTTP client to support generic `request()` method used by the API proxy
  - Added proper response content and headers to mock responses
  - Added comprehensive test suite (`TestAdminApiProxyAuth`) with 9 tests covering:
    - Blocking of POST/PUT/DELETE/PATCH without auth
    - Allowing mutations with proper auth headers
    - Allowing read-only GET requests without auth
    - Allowing mutations when admin is disabled

## Implementation Details
- The authentication check uses the `X-Forwarded-User` header set by OAuth2Proxy, which is the standard way to pass authenticated user information in reverse proxy setups
- Read-only operations (GET) are not blocked to allow public API access when appropriate
- The check only applies when `admin_enabled` is true, maintaining backward compatibility
- Frontend checks provide early feedback while backend checks provide security enforcement

https://claude.ai/code/session_01HYuz5XLjYZ6JaowWqz643A