### PR TITLE
Improve node display with descriptions, members, and emoji extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,25 @@ Examples:
 - JSON columns for flexible data (path_hashes, parsed_data, etc.)
 - Foreign keys reference nodes by UUID, not public_key
 
+## Standard Node Tags
+
+Node tags are flexible key-value pairs that allow custom metadata to be attached to nodes. While tags are completely optional and freeform, the following standard tag keys are recommended for consistent use across the web dashboard:
+
+| Tag Key | Description | Usage |
+|---------|-------------|-------|
+| `name` | Node display name | Used as the primary display name throughout the UI (overrides the advertised name) |
+| `description` | Short description | Displayed as supplementary text under the node name |
+| `member_id` | Member identifier reference | Links the node to a network member (matches `member_id` in Members table) |
+| `lat` | GPS latitude override | Overrides node-reported latitude for map display |
+| `lon` | GPS longitude override | Overrides node-reported longitude for map display |
+| `elevation` | GPS elevation override | Overrides node-reported elevation |
+| `role` | Node role/purpose | Used for website presentation and filtering (e.g., "gateway", "repeater", "sensor") |
+
+**Important Notes:**
+- All tags are optional - nodes can function without any tags
+- Tag keys are case-sensitive
+- The `member_id` tag should reference a valid `member_id` from the Members table
+
 ## Testing Guidelines
 
 ### Unit Tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docker](https://github.com/ipnet-mesh/meshcore-hub/actions/workflows/docker.yml/badge.svg)](https://github.com/ipnet-mesh/meshcore-hub/actions/workflows/docker.yml)
 [![BuyMeACoffee](https://raw.githubusercontent.com/pachadotdev/buymeacoffee-badges/main/bmc-donate-yellow.svg)](https://www.buymeacoffee.com/jinglemansweep)
 
-Python 3.14+ platform for managing and orchestrating MeshCore mesh networks.
+Python 3.13+ platform for managing and orchestrating MeshCore mesh networks.
 
 ![MeshCore Hub Web Dashboard](docs/images/web.png)
 
@@ -476,15 +476,16 @@ Tags are keyed by public key in YAML format:
 ```yaml
 # Each key is a 64-character hex public key
 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:
-  friendly_name: Gateway Node
+  name: Gateway Node
+  description: Main network gateway
   role: gateway
   lat: 37.7749
   lon: -122.4194
-  is_online: true
+  member_id: alice
 
 fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210:
-  friendly_name: Oakland Repeater
-  altitude: 150
+  name: Oakland Repeater
+  elevation: 150
 ```
 
 Tag values can be:

--- a/src/meshcore_hub/api/routes/advertisements.py
+++ b/src/meshcore_hub/api/routes/advertisements.py
@@ -29,6 +29,16 @@ def _get_tag_name(node: Optional[Node]) -> Optional[str]:
     return None
 
 
+def _get_tag_description(node: Optional[Node]) -> Optional[str]:
+    """Extract description tag from a node's tags."""
+    if not node or not node.tags:
+        return None
+    for tag in node.tags:
+        if tag.key == "description":
+            return tag.value
+    return None
+
+
 def _fetch_receivers_for_events(
     session: DbSession,
     event_type: str,
@@ -210,6 +220,7 @@ async def list_advertisements(
             "name": adv.name,
             "node_name": row.source_name,
             "node_tag_name": _get_tag_name(source_node),
+            "node_tag_description": _get_tag_description(source_node),
             "adv_type": adv.adv_type or row.source_adv_type,
             "flags": adv.flags,
             "received_at": adv.received_at,
@@ -292,6 +303,7 @@ async def get_advertisement(
         "name": adv.name,
         "node_name": result.source_name,
         "node_tag_name": _get_tag_name(source_node),
+        "node_tag_description": _get_tag_description(source_node),
         "adv_type": adv.adv_type or result.source_adv_type,
         "flags": adv.flags,
         "received_at": adv.received_at,

--- a/src/meshcore_hub/common/schemas/messages.py
+++ b/src/meshcore_hub/common/schemas/messages.py
@@ -119,6 +119,9 @@ class AdvertisementRead(BaseModel):
     node_tag_name: Optional[str] = Field(
         default=None, description="Node name from tags"
     )
+    node_tag_description: Optional[str] = Field(
+        default=None, description="Node description from tags"
+    )
     adv_type: Optional[str] = Field(default=None, description="Node type")
     flags: Optional[int] = Field(default=None, description="Capability flags")
     received_at: datetime = Field(..., description="When received")

--- a/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
@@ -2,7 +2,7 @@ import { apiGet } from '../api.js';
 import {
     html, litRender, nothing,
     getConfig, typeEmoji, formatDateTime,
-    truncateKey, errorAlert, t,
+    truncateKey, errorAlert, copyToClipboard, t,
 } from '../components.js';
 import { iconError } from '../icons.js';
 
@@ -30,6 +30,7 @@ export async function render(container, params, router) {
 
         const config = getConfig();
         const tagName = node.tags?.find(t => t.key === 'name')?.value;
+        const tagDescription = node.tags?.find(t => t.key === 'description')?.value;
         const displayName = tagName || node.name || t('common.unnamed_node');
         const emoji = typeEmoji(node.adv_type);
 
@@ -140,10 +141,13 @@ export async function render(container, params, router) {
     </ul>
 </div>
 
-<h1 class="text-3xl font-bold mb-6">
-    <span title=${node.adv_type || t('node_types.unknown')}>${emoji}</span>
-    ${displayName}
-</h1>
+<div class="flex items-start gap-4 mb-6">
+    <span class="text-6xl flex-shrink-0" title=${node.adv_type || t('node_types.unknown')}>${emoji}</span>
+    <div class="flex-1 min-w-0">
+        <h1 class="text-3xl font-bold">${displayName}</h1>
+        ${tagDescription ? html`<p class="text-base-content/70 mt-2">${tagDescription}</p>` : nothing}
+    </div>
+</div>
 
 ${heroHtml}
 
@@ -151,7 +155,9 @@ ${heroHtml}
     <div class="card-body">
         <div>
             <h3 class="font-semibold opacity-70 mb-2">${t('common.public_key')}</h3>
-            <code class="text-sm bg-base-200 p-2 rounded block break-all">${node.public_key}</code>
+            <code class="text-sm bg-base-200 p-2 rounded block break-all cursor-pointer hover:bg-base-300 select-all"
+                  @click=${(e) => copyToClipboard(e, node.public_key)}
+                  title="Click to copy">${node.public_key}</code>
         </div>
         <div class="flex flex-wrap gap-x-8 gap-y-2 mt-4 text-sm">
             <div><span class="opacity-70">${t('common.first_seen_label')}</span> ${formatDateTime(node.first_seen)}</div>


### PR DESCRIPTION
Enhances the web dashboard's node presentation to match official MeshCore app behavior and provide better user experience:

- Extract emoji from node names (e.g., "🏠 Home Gateway" uses 🏠 icon)
- Display description tags under node names across all list pages
- Add Member column to show network member associations
- Add copyable public key columns on Nodes and Advertisements pages
- Create reusable renderNodeDisplay() component for consistency
- Improve node detail page layout with larger emoji and inline description
- Document standard node tags (name, description, member_id, etc.)
- Fix documentation: correct Python version requirement and tag examples