### PR TITLE
Update MeshCore URLs to meshcore.io and tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ This project is licensed under the GNU General Public License v3.0 or later (GPL
 
 ## Acknowledgments
 
-- [MeshCore](https://meshcore.dev/) - The mesh networking protocol
+- [MeshCore](https://meshcore.io/) - The mesh networking protocol
 - [meshcore](https://github.com/fdlamotte/meshcore) - Python library for MeshCore devices
 - [meshcore-packet-capture](https://github.com/agessaman/meshcore-packet-capture) - RF packet capture and MQTT publisher for data ingestion
 - [meshcore-mqtt-broker](https://github.com/michaelhart/meshcore-mqtt-broker) - WebSocket MQTT broker with MeshCore public key authentication. The Docker image (`ghcr.io/ipnet-mesh/meshcore-mqtt-broker`) is built and published by a GitHub Action in this repository that clones the upstream source, as the upstream project does not currently provide a public Docker image (although a [PR has been submitted](https://github.com/michaelhart/meshcore-mqtt-broker/pull/1) to add this).

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -248,7 +248,7 @@ Homepage-specific content:
 | `advertisements` | Advertisements | Homepage stat label |
 | `messages` | Messages | Homepage stat label |
 
-**Note:** MeshCore tagline "Connecting people and things, without using the internet" is hardcoded in English and should not be translated (trademark).
+**Note:** MeshCore tagline "Off-Grid, Open-Source Encrypted Messaging" is hardcoded in English and should not be translated (trademark).
 
 ### 8. `dashboard`
 

--- a/example/content/pages/join.md
+++ b/example/content/pages/join.md
@@ -70,7 +70,7 @@ The app connects via Bluetooth to your Companion node, allowing you to send mess
 
 ## Flashing Firmware
 
-1. Use the [MeshCore Web Flasher](https://flasher.meshcore.co.uk/) for easy browser-based flashing
+1. Use the [MeshCore Web Flasher](https://flasher.meshcore.io/) for easy browser-based flashing
 2. Select your device type and region (frequency)
 3. Connect via USB and flash
 

--- a/src/meshcore_hub/web/static/js/spa/pages/home.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/home.js
@@ -158,12 +158,12 @@ export async function render(container, params, router) {
     <div class="card bg-base-100 shadow-xl">
         <div class="card-body flex flex-col items-center justify-center">
             <p class="text-sm opacity-70 mb-4 text-center">${t('home.meshcore_attribution')}</p>
-            <a href="https://meshcore.co.uk/" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity">
+            <a href="https://meshcore.io/" target="_blank" rel="noopener noreferrer" class="hover:opacity-80 transition-opacity">
                 <img src="/static/img/meshcore.svg" alt="MeshCore" class="theme-logo theme-logo--invert-light h-8" />
             </a>
-            <p class="text-xs opacity-50 mt-4 text-center">Connecting people and things, without using the internet</p>
+            <p class="text-xs opacity-50 mt-4 text-center">Off-Grid, Open-Source Encrypted Messaging</p>
             <div class="flex gap-2 mt-4">
-                <a href="https://meshcore.co.uk/" target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm">
+                <a href="https://meshcore.io/" target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm">
                     ${iconGlobe('h-4 w-4 mr-1')}
                     ${t('links.website')}
                 </a>


### PR DESCRIPTION
## Summary

- Replace all references to `meshcore.dev` and `meshcore.co.uk` with `meshcore.io` across the codebase (README, home page, example content)
- Update `flasher.meshcore.co.uk` to `flasher.meshcore.io`
- Update the MeshCore tagline from "Connecting people and things, without using the internet" to "Off-Grid, Open-Source Encrypted Messaging"
- Update the i18n docs to reflect the new tagline