### PR TITLE
feat: user profile description/url + members hero link + profile layout fix

### DIFF
--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -94,7 +94,6 @@
 .btn-hero-members {
     --btn-color: var(--color-members);
     --btn-border-color: var(--color-members);
-    --btn-bg: transparent;
 }
 
 /* ==========================================================================

--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -91,6 +91,11 @@
 #app .btn-outline:hover {
     color: #fff !important;
 }
+.btn-hero-members {
+    --btn-color: var(--color-members);
+    --btn-border-color: var(--color-members);
+    --btn-bg: transparent;
+}
 
 /* ==========================================================================
    Panel Glow

--- a/src/meshcore_hub/web/static/js/spa/pages/home.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/home.js
@@ -4,7 +4,7 @@ import {
     getConfig, errorAlert, pageColors, renderStatCard, t,
 } from '../components.js';
 import {
-    iconDashboard, iconNodes, iconAdvertisements, iconMessages, iconMap,
+    iconDashboard, iconNodes, iconAdvertisements, iconMessages, iconMembers, iconMap,
     iconPage, iconInfo, iconChart, iconGlobe, iconGithub,
 } from '../icons.js';
 
@@ -77,6 +77,11 @@ function renderHeroSection({ networkName, logoUrl, logoInvertLight, networkCity,
                 <a href="/messages" class="btn btn-outline btn-accent">
                     ${iconMessages('h-5 w-5 mr-2')}
                     ${t('entities.messages')}
+                </a>` : nothing}
+                ${features.members !== false ? html`
+                <a href="/members" class="btn btn-outline btn-hero-members">
+                    ${iconMembers('h-5 w-5 mr-2')}
+                    ${t('entities.members')}
                 </a>` : nothing}
                 ${features.map !== false ? html`
                 <a href="/map" class="btn btn-outline btn-warning">

--- a/src/meshcore_hub/web/static/js/spa/pages/profile.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/profile.js
@@ -63,8 +63,10 @@ function renderPublicProfile(profile, config, target) {
 
 <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
-        <h2 class="card-title">${profile.name || t('common.unnamed')}</h2>
-        ${profile.callsign ? html`<span class="badge badge-neutral">${profile.callsign}</span>` : nothing}
+        <h2 class="card-title">
+            ${profile.name || t('common.unnamed')}
+            ${profile.callsign ? html`<span class="badge badge-neutral badge-sm">${profile.callsign}</span>` : nothing}
+        </h2>
         ${renderRoleBadges(profile.roles)}
         ${profile.description ? html`<p class="text-sm opacity-80 mt-2">${profile.description}</p>` : nothing}
         ${profile.url ? html`<a href="${profile.url}" target="_blank" rel="noopener noreferrer" class="link link-primary text-sm mt-1 inline-block">${profile.url}</a>` : nothing}


### PR DESCRIPTION
## Summary

- Adds `description` and `url` fields to user profiles with full API, frontend, and i18n support
- Fixes a bug where clearing nullable fields (callsign, description, url) by setting to `null` was silently ignored
- `name` remains non-nullable — set by IdP, cannot be cleared via API
- Adds Members link to homepage hero after Messages, using `--color-members` palette
- Fixes profile view: callsign badge now inline with name, matching Members card layout

### Changes

**Backend (user profile fields):**
- New `description` (Text) and `url` (String 2048) columns on `user_profiles` with Alembic migration
- Fields added to all Pydantic schemas: `UserProfileRead`, `UserProfilePublic`, `UserProfileUpdate` (with `AnyUrl` validation), `UserProfileListItem`
- API routes updated to include fields in all response constructions
- Update handler reworked: `name` uses explicit `is not None` guard, nullable fields use `model_dump(exclude_unset=True)` so explicit `null` clears to `NULL`

**Frontend:**
- Profile page: added description and URL inputs to edit form, and render on public view
- Members page: description text and URL link per member tile
- Homepage hero: Members link card after Messages, using `--color-members` orange palette, gated by `FEATURE_MEMBERS` and `OIDC_ENABLED`
- Profile view: callsign badge now inline with name inside `<h2 class="card-title">`

**i18n:** 4 new keys: `description_label`, `description_placeholder`, `url_label`, `url_placeholder`

**Tests:** 7 new API tests covering description/url CRUD, URL validation, null-clearing, and name non-nullability