### PR TITLE
fix: include operators in members count widget

### DIFF
--- a/src/meshcore_hub/api/routes/dashboard.py
+++ b/src/meshcore_hub/api/routes/dashboard.py
@@ -225,10 +225,7 @@ async def get_stats(
         session.execute(
             select(func.count())
             .select_from(UserProfile)
-            .where(
-                UserProfile.roles.contains(member_role),
-                ~UserProfile.roles.contains(operator_role),
-            )
+            .where(UserProfile.roles.contains(member_role))
         ).scalar()
         or 0
     )


### PR DESCRIPTION
## Summary
- Remove operator exclusion filter from `total_members` dashboard stats query so operators (who also hold the `member` role) are counted in both the Operators and Members widgets on the homepage