### PR TITLE
docs: add MeshCore Hub Networks section and reorder translation alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Python 3.14+ platform for managing and orchestrating MeshCore mesh networks.
 
 Local mesh communities that are using MeshCore Hub:
 
-[IPNet (Ipswich, UK)](https://ipnt.uk/) | [CumbriaCQ MeshCore (Cumbria, UK)](https://meshcore.cumbriacq.com/) | [Skynet (Wales, UK)](https://skynet.cyberdyne-systems.wales/) | [MeshCore Iasi (Romania)](https://meshcore-iasi.ro/)
+[IPNet (Ipswich, UK)](https://ipnt.uk/) | [CumbriaCQ MeshCore (Cumbria, UK)](https://meshcore.cumbriacq.com/) | [Skynet (Wales, UK)](https://skynet.cyberdyne-systems.wales/)
+
+[MeshCore Iasi (Romania)](https://meshcore-iasi.ro/)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Python 3.14+ platform for managing and orchestrating MeshCore mesh networks.
 
 ![MeshCore Hub Web Dashboard](docs/images/web.png)
 
-> [!IMPORTANT]
-> **Help Translate MeshCore Hub** 🌍
->
-> We need volunteers to translate the web dashboard! Currently only English is available. Check out the [Translation Guide](docs/i18n.md) to contribute a language pack. Partial translations welcome!
+## MeshCore Hub Networks
+
+Local mesh communities that are using MeshCore Hub:
+
+[IPNet (Ipswich, UK)](https://ipnt.uk/) | [CumbriaCQ MeshCore (Cumbria, UK)](https://meshcore.cumbriacq.com/) | [Skynet (Wales, UK)](https://skynet.cyberdyne-systems.wales/) | [MeshCore Iasi (Romania)](https://meshcore-iasi.ro/)
 
 ## Overview
 
@@ -618,6 +619,11 @@ meshcore-hub/
 5. Commit your changes (`git commit -m 'Add amazing feature'`)
 6. Push to the branch (`git push origin feature/amazing-feature`)
 7. Open a Pull Request
+
+> [!IMPORTANT]
+> **Help Translate MeshCore Hub** 🌍
+>
+> We need volunteers to translate the web dashboard! Currently only English is available. Check out the [Translation Guide](docs/i18n.md) to contribute a language pack. Partial translations welcome!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ Python 3.14+ platform for managing and orchestrating MeshCore mesh networks.
 
 ![MeshCore Hub Web Dashboard](docs/images/web.png)
 
-## MeshCore Hub Networks
-
-Local mesh communities that are using MeshCore Hub:
-
-[IPNet (Ipswich, UK)](https://ipnt.uk/) | [CumbriaCQ MeshCore (Cumbria, UK)](https://meshcore.cumbriacq.com/) | [Skynet (Wales, UK)](https://skynet.cyberdyne-systems.wales/)
-
-[MeshCore Iasi (Romania)](https://meshcore-iasi.ro/)
-
 ## Overview
 
 MeshCore Hub provides a complete solution for monitoring, collecting, and interacting with MeshCore mesh networks. Data ingestion is handled by [meshcore-packet-capture](https://github.com/agessaman/meshcore-packet-capture), which observes MeshCore RF traffic and publishes decoded packets to MQTT. It consists of multiple components that work together:
@@ -29,6 +21,15 @@ MeshCore Hub provides a complete solution for monitoring, collecting, and intera
 | **Collector**     | Subscribes to MQTT events and persists them to a database    |
 | **API**           | REST API for querying data                                   |
 | **Web Dashboard** | Single Page Application (SPA) for visualizing network status |
+
+## MeshCore Hub Networks
+
+Local mesh communities that are using MeshCore Hub:
+
+- [IPNet (Ipswich, UK)](https://ipnt.uk/)
+- [CumbriaCQ MeshCore (Cumbria, UK)](https://meshcore.cumbriacq.com/)
+- [Skynet (Wales, UK)](https://skynet.cyberdyne-systems.wales/)
+- [MeshCore Iasi (Romania)](https://meshcore-iasi.ro/)
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Add "MeshCore Hub Networks" section below the screenshot listing communities using MeshCore Hub (IPNet, CumbriaCQ, Skynet, MeshCore Iasi)
- Move "Help Translate MeshCore Hub" alert from the top of the README to after the Contributing section