### PR TITLE
fix(web): show node last_seen instead of adopted_at on profile

### DIFF
--- a/src/meshcore_hub/api/routes/user_profiles.py
+++ b/src/meshcore_hub/api/routes/user_profiles.py
@@ -46,6 +46,7 @@ def _build_adopted_nodes(profile: UserProfile) -> list[AdoptedNodeRead]:
                 name=assoc.node.name,
                 adv_type=assoc.node.adv_type,
                 adopted_at=assoc.adopted_at,
+                last_seen=assoc.node.last_seen,
             )
         )
     return adopted_nodes

--- a/src/meshcore_hub/common/schemas/user_profiles.py
+++ b/src/meshcore_hub/common/schemas/user_profiles.py
@@ -75,6 +75,9 @@ class AdoptedNodeRead(BaseModel):
     name: Optional[str] = Field(default=None, description="Node display name")
     adv_type: Optional[str] = Field(default=None, description="Advertisement type")
     adopted_at: datetime = Field(..., description="When the node was adopted")
+    last_seen: Optional[datetime] = Field(
+        default=None, description="Timestamp of the node's most recent activity"
+    )
 
     class Config:
         from_attributes = True

--- a/src/meshcore_hub/web/static/js/spa/pages/profile.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/profile.js
@@ -7,15 +7,15 @@ import {
 
 function renderAdoptedNode(node) {
     const displayName = node.name || node.public_key.slice(0, 12) + '...';
-    const relTime = formatRelativeTime(node.adopted_at);
-    const fullTime = formatDateTime(node.adopted_at);
+    const relTime = node.last_seen ? formatRelativeTime(node.last_seen) : '-';
+    const fullTime = node.last_seen ? formatDateTime(node.last_seen) : '-';
 
     return html`<a href="/nodes/${node.public_key}" class="flex items-center justify-between gap-3 p-3 bg-base-200 rounded-lg hover:bg-base-300 transition-colors">
         <div class="flex-1 min-w-0">
             <div class="font-medium text-sm truncate">${displayName}</div>
             <div class="font-mono text-xs opacity-60 truncate">${node.public_key}</div>
         </div>
-        <time class="text-xs opacity-60 whitespace-nowrap shrink-0" datetime=${node.adopted_at} title=${fullTime} data-relative-time>${relTime}</time>
+        <time class="text-xs opacity-60 whitespace-nowrap shrink-0" datetime=${node.last_seen || nothing} title=${fullTime} data-relative-time>${relTime}</time>
     </a>`;
 }
 

--- a/tests/test_api/test_user_profiles.py
+++ b/tests/test_api/test_user_profiles.py
@@ -206,6 +206,7 @@ class TestGetProfile:
         assert len(data["nodes"]) == 1
         assert data["nodes"][0]["public_key"] == "abc123def456abc123def456abc123de"
         assert "adopted_at" in data["nodes"][0]
+        assert data["nodes"][0]["last_seen"] is not None
 
     def test_get_profile_returns_roles(self, client_no_auth, sample_user_profile):
         """Test that profile includes roles."""


### PR DESCRIPTION
## Problem

The User Profile page shows a "last seen" timestamp for each of a user's adopted nodes, but it was always wrong — e.g. showing "35 days ago" even for nodes that had advertised today.

## Root cause

The `<time>` element in `renderAdoptedNode()` rendered `node.adopted_at` (the date the node was *adopted*) instead of the node's most recent activity. Since the nodes were adopted ~35 days ago, the relative time was stuck at the adoption date.

The underlying gap: the API's `AdoptedNodeRead` schema never exposed the node's `last_seen` field, so the frontend had nothing else to display.

## Changes

- **`common/schemas/user_profiles.py`** — add `last_seen: Optional[datetime]` to `AdoptedNodeRead`.
- **`api/routes/user_profiles.py`** — populate it from `assoc.node.last_seen` in `_build_adopted_nodes()` (flows through to both list and detail profile endpoints).
- **`web/static/js/spa/pages/profile.js`** — render `node.last_seen` instead of `adopted_at`, falling back to `-` when null (matching the `nodes.js` / `node-detail.js` convention).
- **`tests/test_api/test_user_profiles.py`** — assert `last_seen` is present and non-null in the profile response.

## Testing

- `pytest tests/test_api/test_user_profiles.py` — 32 passed.
- Rebuilt the esbuild bundle locally to confirm the change compiles. Note: `dist/` is gitignored and built at deploy time, so it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)