### PR TITLE
fix(web): resolve TDZ error on profile page from shadowed signal var

### DIFF
--- a/src/meshcore_hub/web/static/js/spa/pages/profile.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/profile.js
@@ -167,7 +167,6 @@ ${flashHtml}
 </div>`, container);
 
         const ac = new AbortController();
-        const signal = ac.signal;
 
         container.querySelector('#profile-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -184,7 +183,7 @@ ${flashHtml}
             } catch (err) {
                 router.navigate('/profile?error=' + encodeURIComponent(err.message), true);
             }
-        }, { signal });
+        }, { signal: ac.signal });
 
         return () => ac.abort();
 


### PR DESCRIPTION
## Summary

Fixes #233 — the user profile page failed to render with `Cannot access 'h' before initialization` (or `can't access lexical declaration 'h' before initialization`).

## Root cause

A temporal dead zone (TDZ) bug from variable shadowing in `profile.js`. In the `/profile/me` branch, `signal` is destructured from `params` and used in the `apiGet('/api/v1/user/profile/me', {}, { signal })` call. Further down in the **same block scope**, the code redeclared `const signal = ac.signal`. Because `const` is block-scoped and hoisted, the entire `try` block bound `signal` to the later declaration, so the earlier `apiGet` reference hit the TDZ. After minification `signal` became `h`, producing the reported error.

## Fix

- Removed the redundant `const signal = ac.signal;` declaration.
- Passed `ac.signal` directly to the form submit listener's options.

The two abort signals are now unambiguous — the params signal for the data fetch, `ac.signal` for the listener cleanup. Rebuilt the frontend bundle and confirmed the new chunk emits no shadowing collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)