### PR TITLE
fix(docker): correct OCI source label to ipnet-mesh/meshcore-hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ FROM python:3.14-slim AS runtime
 # Labels
 LABEL org.opencontainers.image.title="MeshCore Hub" \
       org.opencontainers.image.description="Python monorepo for managing MeshCore mesh networks" \
-      org.opencontainers.image.source="https://github.com/meshcore-dev/meshcore-hub"
+      org.opencontainers.image.source="https://github.com/ipnet-mesh/meshcore-hub"
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary

Tiny one-line fix to the `org.opencontainers.image.source` OCI label in `Dockerfile`. Triggers the optimised CI and Docker workflows from #252 to verify they behave correctly on PR + merge.

## Why

The label was pointing at `meshcore-dev/meshcore-hub` (the upstream MeshCore project's org) instead of this repo's canonical location at `ipnet-mesh/meshcore-hub`. Verified against:

- `git remote -v` → `git@github.com:ipnet-mesh/meshcore-hub.git`
- All `raw.githubusercontent.com/ipnet-mesh/...` URLs in `README.md` and `docs/upgrading.md`
- `docker-mqtt-broker.yml` `IMAGE_NAME: ipnet-mesh/meshcore-mqtt-broker`

The `meshcore-dev/MeshCore` references elsewhere in the repo (`docs/plans/...`, `example/content/pages/join.md`) point at the **MeshCore firmware project**, not this repo, so those are correct and unchanged.

## Impact

- No runtime behaviour change
- Published image metadata will now correctly link back to this repo (visible on `ghcr.io` package page and via `docker inspect`)
- Serves double-duty as a smoke test for the workflow optimisations landed in #252:
  - On PR: `ci.yml` should run (Dockerfile is not in `paths-ignore`); `lint` + `test` only (`build` job gated to push events).
  - On merge: `docker.yml` should build and push `ghcr.io/ipnet-mesh/meshcore-hub:main` + `:sha-<short>`.

## Verify after merge

\`\`\`bash
docker pull ghcr.io/ipnet-mesh/meshcore-hub:main
docker inspect ghcr.io/ipnet-mesh/meshcore-hub:main \
  --format '{{ index .Config.Labels "org.opencontainers.image.source" }}'
# Expect: https://github.com/ipnet-mesh/meshcore-hub
\`\`\`