### PR TITLE
ci: prune old untagged GHCR package versions

### DIFF
--- a/.github/workflows/docker-mqtt-broker.yml
+++ b/.github/workflows/docker-mqtt-broker.yml
@@ -117,6 +117,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Delete old untagged package versions
+        if: steps.decide.outputs.changed == 'true'
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: meshcore-mqtt-broker
+          package-type: container
+          delete-only-untagged-versions: "true"
+          min-versions-to-keep: 10
+
       - name: Skip build (unchanged)
         if: steps.decide.outputs.changed != 'true'
         run: echo "Upstream ${{ steps.check.outputs.upstream_sha }} already built; skipping."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Delete old untagged package versions
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          delete-only-untagged-versions: "true"
+          min-versions-to-keep: 10
+
       - name: Test Docker image
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
## Summary

Adds `actions/delete-package-versions@v5` to both Docker build pipelines (`docker.yml` and `docker-mqtt-broker.yml`) to clean up the orphaned **untagged** manifests that pile up in GHCR from multi-arch (`amd64,arm64`) rebuilds.

## Behaviour

- `delete-only-untagged-versions: "true"` → **never deletes any tagged version** (`v1.2.3`, `latest`, `main`, `sha-*` all survive).
- `min-versions-to-keep: 10` → keeps the newest untagged manifests, protecting the just-pushed image's own platform/attestation child manifests.
- `continue-on-error: true` → a cleanup hiccup never fails an otherwise-successful publish.
- `owner`/`token` default to `ipnet-mesh` / `github.token`; the existing `packages: write` permission authorizes deletion.

Cleanup runs only after a real push: guarded by `github.event_name != 'pull_request'` in `docker.yml` and `steps.decide.outputs.changed == 'true'` in `docker-mqtt-broker.yml`.

## Tradeoff

This action cannot distinguish tag types on container packages (it matches the sha256 digest, not the tag), so `sha-*` tags are intentionally **not** pruned — that was a deliberate choice to guarantee no tagged release is ever removed.

## Verification

- Both workflows pass `actionlint` and parse as valid YAML.
- Post-merge: confirm the cleanup step logs in a real run and that all tags remain on the GHCR package pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)