### PR TITLE
fix: normalize packets feature flag check to !== false

### DIFF
--- a/src/meshcore_hub/web/static/js/spa/app.js
+++ b/src/meshcore_hub/web/static/js/spa/app.js
@@ -96,7 +96,7 @@ if (features.messages !== false) {
 if (features.advertisements !== false) {
     router.addRoute('/advertisements', pageHandler(pages.advertisements));
 }
-if (features.packets === true) {
+if (features.packets !== false) {
     router.addRoute('/packets', pageHandler(pages.packets));
     router.addRoute('/packets/hash/:hash', pageHandler(pages.packetGroupDetail));
     router.addRoute('/packets/:id', pageHandler(pages.packetDetail));
@@ -178,7 +178,7 @@ function updatePageTitle(pathname) {
     if (features.channels !== false) titles['/channels'] = composePageTitle('entities.channels');
     if (features.messages !== false) titles['/messages'] = composePageTitle('entities.messages');
     if (features.advertisements !== false) titles['/advertisements'] = composePageTitle('entities.advertisements');
-    if (features.packets === true) titles['/packets'] = composePageTitle('entities.packets');
+    if (features.packets !== false) titles['/packets'] = composePageTitle('entities.packets');
     if (features.map !== false) titles['/map'] = composePageTitle('entities.map');
     if (features.members !== false) titles['/members'] = composePageTitle('entities.members');
     titles['/profile'] = composePageTitle('links.profile');
@@ -232,7 +232,7 @@ function renderMobileNav(config) {
     if (features.messages !== false) {
         items.push(html`<li><a href="/messages" data-nav-link>${iconMessages('h-5 w-5 nav-icon-messages')} ${t('entities.messages')}</a></li>`);
     }
-    if (features.packets === true) {
+    if (features.packets !== false) {
         items.push(html`<li><a href="/packets" data-nav-link>${iconPackets('h-5 w-5 nav-icon-packets')} ${t('entities.packets')}</a></li>`);
     }
     if (features.map !== false) {

--- a/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
@@ -39,7 +39,7 @@ export async function render(container, params, router) {
 
     const config = getConfig();
     const features = config.features || {};
-    const packetsEnabled = features.packets === true;
+    const packetsEnabled = features.packets !== false;
     const tz = config.timezone || '';
     const tzBadge = tz && tz !== 'UTC' ? html`<span class="text-sm opacity-60">${tz}</span>` : nothing;
     const navigate = (url) => router.navigate(url);

--- a/src/meshcore_hub/web/static/js/spa/pages/home.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/home.js
@@ -105,7 +105,7 @@ function renderHeroSection({ networkName, logoUrl, logoInvertLight, networkCity,
                     label: t('entities.messages'),
                     colorVar: '--color-messages',
                 }) : nothing}
-                ${features.packets === true ? renderNavCard({
+                ${features.packets !== false ? renderNavCard({
                     href: '/packets',
                     icon: iconPackets('w-full h-full'),
                     label: t('entities.packets'),

--- a/src/meshcore_hub/web/static/js/spa/pages/messages.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/messages.js
@@ -26,7 +26,7 @@ export async function render(container, params, router) {
 
     const config = getConfig();
     const features = config.features || {};
-    const packetsEnabled = features.packets === true;
+    const packetsEnabled = features.packets !== false;
     let channelLabels = new Map();
     const tz = config.timezone || '';
     const tzBadge = tz && tz !== 'UTC' ? html`<span class="text-sm opacity-60">${tz}</span>` : nothing;


### PR DESCRIPTION
## Summary

The `packets` feature was the only flag gated with a strict `=== true` check in the SPA JavaScript, while every other feature flag uses the `!== false` (enabled unless explicitly disabled) pattern. This asymmetry meant that any truthy-but-not-`true` value for `features.packets` would hide Packets alone — visible in the server-rendered desktop nav but missing from SPA routes and the mobile nav.

## Changes

Flipped all 6 occurrences of `features.packets === true` to `features.packets !== false` so packets follows the same gating pattern as every other feature flag:

| File | Location |
| --- | --- |
| `web/static/js/spa/app.js` | route registration (L99), page title (L181), mobile nav (L235) |
| `web/static/js/spa/pages/home.js` | home nav card (L108) |
| `web/static/js/spa/pages/messages.js` | packet-detail link gate (L29) |
| `web/static/js/spa/pages/advertisements.js` | packet-detail link gate (L42) |

Left alone (intentionally):
- `app.js:69` — `config.system_maintenance === true` is not a feature flag.
- `spa.html:76` — `{% if features.packets %}` is already consistent with every other Jinja flag.

## Test plan

- [x] `pytest --no-cov tests/test_web/test_features.py` — 23 passed (exercises server-rendered nav with real booleans; unaffected by JS-only change)
- [x] `pre-commit` clean on changed files
- [ ] Manual: load `/` with default config — confirm Packets appears in desktop nav, mobile nav, home grid, and `/packets` route resolves
- [ ] Manual: with `FEATURE_PACKETS=false` — confirm Packets is hidden everywhere