### PR TITLE
fix: ensure CI required checks run on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ on:
       - "FUNDING.yml"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - ".env.example"
-      - "LICENSE"
-      - "FUNDING.yml"
 
 permissions:
   contents: read
@@ -85,7 +79,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [lint, test]
-    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The repo ruleset (id `12664387`) requires three status checks on `main`: `Lint`, `Test`, and `Build Package` (`strict_required_status_checks_policy: true`). Two issues prevented PRs from merging:

1. **`ci.yml` `paths-ignore` on `pull_request`** — for docs/markdown-only PRs, *every* changed file matches the ignore list (`**/*.md`, `docs/**`, `.env.example`, …), so the entire `CI` workflow was skipped and none of the three required checks ever reported. GitHub leaves required checks in an `expected`/`pending` state forever → `mergeStateStatus: BLOCKED`. This is currently blocking **#267** (docs-only).
2. **`build` job gated to `github.event_name == 'push'`** — the `Build Package` required check *never* runs on any pull request, so even code-change PRs are blocked on it.

Required checks and `paths`/`paths-ignore` at the `on:` level are fundamentally incompatible: when a workflow is filtered out, its required checks never report.

## Changes

`.github/workflows/ci.yml`:
- Removed `paths-ignore` from the `pull_request` trigger (kept on `push` to preserve cost savings on `main`).
- Removed the `if: github.event_name == 'push'` condition from the `build` job so `Build Package` reports on PRs.

## Verification

- `pre-commit run --files .github/workflows/ci.yml` — all hooks pass (`check yaml`, yamllint, etc.).
- Diff: 1 file changed, 7 deletions.

## After merge

To unblock **#267**, land this on `main` first, then retrigger CI on #267 (close/reopen or empty commit) so the now-always-running `CI` workflow reports `Lint`/`Test`/`Build Package` against the docs changes.