### PR TITLE
fix(web): stop pre-wrap inflating message table row height

### DIFF
--- a/src/meshcore_hub/web/static/js/spa/pages/messages.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/messages.js
@@ -365,9 +365,9 @@ ${displayContent}`, container);
                     <td class="text-sm whitespace-nowrap">
                         <div>${fromPrimary}</div>
                     </td>
-                    <td class="break-words max-w-md" style="white-space: pre-wrap;">
+                    <td class="break-words max-w-md">
                         <div class="flex items-start gap-2">
-                            <span>${displayMessage}</span>
+                            <span style="white-space: pre-wrap;">${displayMessage}</span>
                             ${spamBadge(msg)}
                         </div>
                     </td>


### PR DESCRIPTION
## Summary

The recent spam-detection change made message table rows noticeably taller. The cause was `white-space: pre-wrap` left on the `<td>` after its content was wrapped in a multi-line `<div>`/`<span>` (to fit the spam badge next to the text). The template literal's own indentation — newlines and spaces around the `<div>` — then rendered as literal whitespace inside the `pre-wrap` cell, padding out **every** row regardless of spam state.

This moves `pre-wrap` onto the inner `<span>` that actually holds the message text, so multi-line message bodies still wrap correctly while the cell's layout whitespace collapses normally.

Only the desktop table view was affected; the card/mobile view never had `pre-wrap` on a whitespace-bearing wrapper.

## Test plan
- [x] `npm run build` regenerates the bundled `dist/` chunk
- [ ] Visually confirm message list rows return to normal height (with and without spam badges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)