### PR TITLE
fix(tests): introspect mounted paths via OpenAPI schema, unpin fastapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
-    # 0.137.0 regressed include_router: routed endpoints no longer appear in
-    # app.routes (they still serve, but introspection breaks). Pin below it
-    # until a fixed release lands. See test_app_factory metrics route checks.
-    "fastapi>=0.100.0,<0.137.0",
+    "fastapi>=0.100.0",
     "starlette>=0.40.0,<1.0.0",
     "uvicorn[standard]>=0.23.0",
     "paho-mqtt>=2.0.0",

--- a/tests/test_api/test_app_factory.py
+++ b/tests/test_api/test_app_factory.py
@@ -27,6 +27,18 @@ def clean_env(monkeypatch):
     return monkeypatch
 
 
+def _served_paths(app):
+    """Return the set of paths the app actually serves.
+
+    FastAPI 0.137 refactored ``include_router`` to keep included routers as
+    nested objects instead of flattening their routes into ``app.routes``, so
+    iterating ``app.routes`` no longer surfaces routed endpoints like
+    ``/metrics``. The OpenAPI schema is the stable, version-independent way to
+    introspect mounted paths (and it resolves router prefixes correctly).
+    """
+    return set(app.openapi()["paths"])
+
+
 def test_factory_reads_database_and_redis_from_env(clean_env):
     """Workers must pick up the real DB/Redis config from env, not the
     hardcoded create_app defaults."""
@@ -71,13 +83,11 @@ def test_factory_metrics_enabled_via_env(clean_env):
     """METRICS_ENABLED=true mounts the /metrics endpoint."""
     clean_env.setenv("METRICS_ENABLED", "true")
     app = create_app_from_env()
-    paths = {getattr(route, "path", None) for route in app.routes}
-    assert "/metrics" in paths
+    assert "/metrics" in _served_paths(app)
 
 
 def test_factory_metrics_disabled_via_env(clean_env):
     """METRICS_ENABLED=false omits the /metrics endpoint."""
     clean_env.setenv("METRICS_ENABLED", "false")
     app = create_app_from_env()
-    paths = {getattr(route, "path", None) for route in app.routes}
-    assert "/metrics" not in paths
+    assert "/metrics" not in _served_paths(app)


### PR DESCRIPTION
## Problem

The Renovate FastAPI bump (#280) fails CI on `test_factory_metrics_enabled_via_env`:

```
AssertionError: assert '/metrics' in {None, '/health', '/api/openapi.json', ...}
```

FastAPI **0.137.0** deliberately refactored `include_router`: included routers are now preserved as nested router objects instead of having their routes flattened into `app.routes`. So `app.routes` contains an internal `_IncludedRouter` (with `path=None`) rather than the `/metrics` `APIRoute`, and the test's `{getattr(route, "path", None) for route in app.routes}` no longer finds it. The endpoint still serves fine — only that introspection broke. FastAPI's release notes now state `router.routes` "should be considered an internal implementation detail."

The previous workaround pinned `fastapi<0.137.0`, which blocks the upgrade indefinitely.

## Fix

- **`tests/test_api/test_app_factory.py`** — introspect mounted paths via the public, stable OpenAPI schema (`app.openapi()["paths"]`) instead of the internal `app.routes` list. Works on both old and new FastAPI and resolves router prefixes correctly.
- **`pyproject.toml`** — drop the `<0.137.0` pin (back to `fastapi>=0.100.0`).

## Verification

Reproduced and verified in an isolated venv with the project installed:

- `tests/test_api/test_app_factory.py`: **5 passed** on both 0.136.3 (current) and 0.137.2 (new).
- Full `tests/test_api/` suite: **462 passed** on 0.137.2.
- Grepped `src/` and `tests/` — no other code relied on the flattened `app.routes`.

## Follow-up

This unblocks #280 — once this lands, rebase #280 (or it can merge, since the pin is now removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)