### PR TITLE
UI cosmetic polish and IBM Plex typography

### DIFF
--- a/build.js
+++ b/build.js
@@ -45,6 +45,22 @@ cpSync(
 
 vendor("chart.js", ["dist/chart.umd.min.js"], "chart.js");
 vendor("qrcodejs", ["qrcode.min.js"], "qrcodejs");
+vendor(
+  "@fontsource-variable/ibm-plex-sans",
+  [
+    "files/ibm-plex-sans-latin-wght-normal.woff2",
+    "files/ibm-plex-sans-latin-ext-wght-normal.woff2",
+  ],
+  "fonts",
+);
+vendor(
+  "@fontsource/ibm-plex-mono",
+  [
+    "files/ibm-plex-mono-latin-400-normal.woff2",
+    "files/ibm-plex-mono-latin-ext-400-normal.woff2",
+  ],
+  "fonts",
+);
 
 console.log("Bundling SPA with esbuild...");
 mkdirSync(DIST, { recursive: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fontsource-variable/ibm-plex-sans": "^5",
+        "@fontsource/ibm-plex-mono": "^5",
         "@tailwindcss/cli": "^4",
         "chart.js": "^4",
         "daisyui": "^5",
@@ -457,6 +459,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-n5PF2iFa0CZT0QYTPzxvZ39opC9LnU0zdoRccoADbs+Dtsd+lbXOZF7RNuIPHcQX1dKjF63sxnRImQIB5eD0Ag==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "esbuild": "^0.28.0"
   },
   "dependencies": {
+    "@fontsource-variable/ibm-plex-sans": "^5",
+    "@fontsource/ibm-plex-mono": "^5",
     "@tailwindcss/cli": "^4",
     "chart.js": "^4",
     "daisyui": "^5",

--- a/src/meshcore_hub/web/middleware.py
+++ b/src/meshcore_hub/web/middleware.py
@@ -54,6 +54,10 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         elif path.startswith("/static/dist/"):
             response.headers["cache-control"] = "public, max-age=31536000, immutable"
 
+        # Vendored font files - stable names referenced from CSS - long-term cache
+        elif path.startswith("/static/vendor/fonts/"):
+            response.headers["cache-control"] = "public, max-age=31536000, immutable"
+
         # Static files without version - short cache as fallback
         elif path.startswith("/static/"):
             response.headers["cache-control"] = "public, max-age=3600"

--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -233,7 +233,7 @@
 }
 
 .prose a:hover {
-    color: var(--color-primary-content);
+    color: color-mix(in oklab, var(--color-primary) 70%, var(--color-base-content));
 }
 
 .prose code {

--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -29,6 +29,12 @@
     --color-members: oklch(0.72 0.17 50);      /* orange */
     --color-neutral: oklch(0.3 0.01 250);     /* subtle dark grey */
     --color-radio: oklch(0.75 0.15 210);     /* cyan — radio tile icons */
+
+    /* Map marker colors — theme-independent, chosen for contrast on map tiles */
+    --color-marker-infra: #3b82f6;
+    --color-marker-infra-border: #1e40af;
+    --color-marker-public: #22c55e;
+    --color-marker-public-border: #15803d;
 }
 
 /* Light mode: darker section colors for contrast on light backgrounds */

--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -66,6 +66,7 @@
 /* Ensure hero heading is pure black/white per theme */
 .hero-title {
     color: #fff;
+    letter-spacing: -0.01em;
 }
 [data-theme="light"] .hero-title {
     color: #000;

--- a/src/meshcore_hub/web/static/css/input.css
+++ b/src/meshcore_hub/web/static/css/input.css
@@ -2,3 +2,48 @@
 @plugin "daisyui";
 @source "../js/";
 @source "../../templates/";
+
+@theme {
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+/* IBM Plex Sans — variable weight (100-700), self-hosted from @fontsource.
+   Files are copied to static/vendor/fonts/ by build.js; unicode-range values
+   are verbatim from the @fontsource package CSS. */
+@font-face {
+  font-family: "IBM Plex Sans";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url("/static/vendor/fonts/ibm-plex-sans-latin-wght-normal.woff2") format("woff2-variations");
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+@font-face {
+  font-family: "IBM Plex Sans";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 700;
+  src: url("/static/vendor/fonts/ibm-plex-sans-latin-ext-wght-normal.woff2") format("woff2-variations");
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}
+
+/* IBM Plex Mono — 400 only (mono is never rendered bold in this app) */
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url("/static/vendor/fonts/ibm-plex-mono-latin-400-normal.woff2") format("woff2");
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url("/static/vendor/fonts/ibm-plex-mono-latin-ext-400-normal.woff2") format("woff2");
+  unicode-range: U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF;
+}

--- a/src/meshcore_hub/web/static/js/charts.js
+++ b/src/meshcore_hub/web/static/js/charts.js
@@ -5,6 +5,11 @@
  * for activity charts used on home and dashboard pages.
  */
 
+// Match app typography (IBM Plex Sans); Chart.js defaults to Helvetica/Arial.
+if (typeof Chart !== 'undefined') {
+    Chart.defaults.font.family = '"IBM Plex Sans", ui-sans-serif, system-ui, sans-serif';
+}
+
 /**
  * Read page colors from CSS custom properties (defined in app.css :root).
  * Falls back to hardcoded values if CSS vars are unavailable.

--- a/src/meshcore_hub/web/static/js/spa/components.js
+++ b/src/meshcore_hub/web/static/js/spa/components.js
@@ -74,7 +74,7 @@ export function mobileSortSelect({ currentSort, currentOrder, navigate, basePath
     return html`<div class="lg:hidden mb-5">
         <div class="flex items-center gap-2">
             <span class="text-xs opacity-60">${t('common.sort_by')}</span>
-            <select class="select select-sm select-bordered flex-1"
+            <select class="select select-sm flex-1"
                     @change=${onChange}>
                 ${sortOptions}
             </select>
@@ -402,7 +402,7 @@ export function copyToClipboard(e, text) {
 export function renderNodeDisplay({ name, description, publicKey, advType, size = 'base' }) {
     const displayName = name || null;
     const emoji = getNodeEmoji(name, advType);
-    const emojiSize = size === 'sm' ? 'text-lg' : 'text-lg';
+    const emojiSize = 'text-lg';
     const nameSize = size === 'sm' ? 'text-sm' : 'text-base';
     const descSize = size === 'sm' ? 'text-xs' : 'text-xs';
 
@@ -718,7 +718,7 @@ export function renderAuthSection(container, config) {
             <div tabindex="0" role="button" class="btn btn-ghost btn-circle btn-sm avatar">
                 ${pictureHtml}
             </div>
-            <ul tabindex="0" class="dropdown-content menu z-50 p-2 shadow bg-base-100 rounded-box w-56 mt-3">
+            <ul tabindex="0" class="dropdown-content menu z-50 p-2 shadow-sm bg-base-100 rounded-box w-56 mt-3">
                 <li class="menu-title">
                     <div class="flex flex-col gap-1">
                         <span class="font-medium">${displayName}</span>
@@ -760,7 +760,7 @@ export function renderFilterCard({ fields, basePath, navigate, submitLabel, clea
 
     if (!collapsible) {
         return html`
-            <div class="card shadow mb-6 panel-solid" style="--panel-color: var(--color-neutral)">
+            <div class="card shadow-sm mb-6 panel-solid" style="--panel-color: var(--color-neutral)">
                 <div class="card-body py-4">${formBody}</div>
             </div>
         `;
@@ -790,7 +790,7 @@ export function renderFilterCard({ fields, basePath, navigate, submitLabel, clea
  */
 export function renderStatCard({ icon, color, title, value, description }) {
     return html`
-        <div class="stat bg-base-200 rounded-box shadow panel-glow" style="--panel-color: ${color}">
+        <div class="stat bg-base-200 rounded-box shadow-sm panel-glow" style="--panel-color: ${color}">
             <div class="stat-figure" style="color: ${color}">${icon}</div>
             <div class="stat-title">${title}</div>
             <div class="stat-value" style="color: ${color}">${value}</div>

--- a/src/meshcore_hub/web/static/js/spa/components.js
+++ b/src/meshcore_hub/web/static/js/spa/components.js
@@ -2,6 +2,18 @@
  * MeshCore Hub SPA - Shared UI Components
  *
  * Reusable rendering functions using lit-html.
+ *
+ * Styling conventions:
+ * - Page <h1>: `text-3xl font-bold`; header row wrapper: `mb-6`.
+ * - Content/detail cards: `card bg-base-100 shadow-xl`; stat cards and
+ *   table wrappers: `shadow-sm`; mobile list cards: `shadow-sm`.
+ * - Muted text: `opacity-70` (primary), `opacity-60` (secondary),
+ *   `opacity-50` (timestamps/tertiary) — not `text-base-content/N`.
+ * - Empty states: `text-center py-8 opacity-70`.
+ * - Panel-level surfaces: `rounded-box`; small inline chips: `rounded`.
+ * - Buttons: table-row icon actions `btn btn-xs btn-ghost`; card-level
+ *   labeled actions `btn btn-xs btn-outline` (+ `btn-error` on delete);
+ *   modal submits full-size `btn btn-primary`, inline/header actions `btn-sm`.
  */
 
 import { html, nothing } from 'lit-html';

--- a/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
@@ -226,14 +226,14 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.search')}</span>
                 </label>
-                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-bordered input-sm w-80" @keydown=${submitOnEnter} />
+                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-sm w-80" @keydown=${submitOnEnter} />
             </div>`,
                 () => html`
             <div class="flex flex-col gap-1 max-w-48">
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('advertisements.filter_route_type_label')}</span>
                 </label>
-                <select name="route_type" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="route_type" class="select select-sm" @change=${autoSubmit}>
                     <option value="flood,transport_flood" ?selected=${route_type === 'flood,transport_flood'}>${t('advertisements.route_type_flood')}</option>
                     <option value="all" ?selected=${route_type === 'all'}>${t('advertisements.route_type_all')}</option>
                     <option value="direct" ?selected=${route_type === 'direct'}>${t('advertisements.route_type_direct')}</option>
@@ -246,7 +246,7 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.filter_operator_label')}</span>
                 </label>
-                <select name="adopted_by" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="adopted_by" class="select select-sm" @change=${autoSubmit}>
                     <option value="" ?selected=${!adopted_by}>${t('common.all_operators')}</option>
                     ${profiles.sort((a, b) => {
                         const na = a.name || a.callsign || '';
@@ -301,7 +301,7 @@ ${observerBadges('flex lg:hidden mb-4')}
     ${mobileCards}
 </div>
 
-<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow">
+<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow-sm">
     <table class="table table-zebra">
         <thead>
             <tr>

--- a/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/advertisements.js
@@ -66,7 +66,7 @@ export async function render(container, params, router) {
         const displayContent = error ? lastContent : content;
         const displayTotal = error ? lastTotal : total;
         litRender(html`
-<div class="flex items-center justify-between mb-4">
+<div class="flex items-center justify-between mb-6">
     <h1 class="text-3xl font-bold">${t('entities.advertisements')}</h1>
     ${tzBadge}
 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/channels.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/channels.js
@@ -142,7 +142,7 @@ export async function render(container, params, router) {
                 : nothing;
 
             const emptyMessage = channelsList.length === 0
-                ? html`<div class="text-center py-10 opacity-60">
+                ? html`<div class="text-center py-8 opacity-70">
                     ${t('common.no_entity_found', { entity: t('entities.channels').toLowerCase() })}
                 </div>`
                 : nothing;
@@ -194,9 +194,9 @@ export async function render(container, params, router) {
             }
 
             litRender(html`
-                <div class="mb-4">
-                    <h1 class="text-2xl font-bold flex items-center gap-2">
-                        ${iconChannel('h-7 w-7')}
+                <div class="mb-6">
+                    <h1 class="text-3xl font-bold flex items-center gap-2">
+                        ${iconChannel('h-8 w-8')}
                         ${t('channels.title')}
                     </h1>
                 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/channels.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/channels.js
@@ -37,7 +37,9 @@ function renderChannelCard(channel, { oidcEnabled, isAdmin, onDelete, onEdit, on
         ? html`<div id="${qrId}" class="qr-container"></div>`
         : nothing;
 
-    return html`<div class="card bg-base-100 shadow-xl cursor-pointer" @click=${() => onNavigate(channelIdx)}>
+    return html`<div class="card bg-base-100 shadow-xl cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary" role="button" tabindex="0"
+        @click=${() => onNavigate(channelIdx)}
+        @keydown=${(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onNavigate(channelIdx); } }}>
         <div class="card-body flex-row gap-4">
             <div class="flex-1 min-w-0">
                 <h2 class="card-title flex items-center gap-2">

--- a/src/meshcore_hub/web/static/js/spa/pages/channels.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/channels.js
@@ -69,19 +69,19 @@ function renderChannelModal({ channel, isEdit, onSave, onCancel }) {
             <h3 class="font-bold text-lg mb-4">${title}</h3>
             <form @submit=${(e) => { e.preventDefault(); onSave(); }}>
                 <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 items-center mb-4">
-                    <label class="label-text text-right">${t('channels.name_label')}</label>
+                    <label class="text-sm opacity-70 text-right">${t('channels.name_label')}</label>
                     <input type="text" id="channel-modal-name" class="input input-bordered input-sm"
                         .value=${isEdit ? channel.name : ''}
                         ?disabled=${isEdit}
                         placeholder="${t('channels.name_label')}"
                         required maxlength="100" />
                     ${!isEdit ? html`
-                    <label class="label-text text-right">${t('channels.key_label')}</label>
+                    <label class="text-sm opacity-70 text-right">${t('channels.key_label')}</label>
                     <input type="text" id="channel-modal-key" class="input input-bordered input-sm font-mono"
                         placeholder="e.g. ABCDEF0123456789..."
                         required minlength="32" maxlength="64"
                         pattern="[0-9A-Fa-f]{32,64}" />` : nothing}
-                    <label class="label-text text-right">${t('channels.visibility_label')}</label>
+                    <label class="text-sm opacity-70 text-right">${t('channels.visibility_label')}</label>
                     <select id="channel-modal-visibility" class="select select-bordered select-sm">
                         <option value="community" .selected=${channel?.visibility === 'community' || !channel}>community</option>
                         <option value="member" .selected=${channel?.visibility === 'member'}>member</option>
@@ -92,7 +92,7 @@ function renderChannelModal({ channel, isEdit, onSave, onCancel }) {
                     <label class="label cursor-pointer justify-start gap-3">
                         <input type="checkbox" id="channel-modal-enabled" class="checkbox checkbox-sm"
                             .checked=${channel?.enabled !== false} />
-                        <span class="label-text">${t('channels.enabled_label')}</span>
+                        <span class="text-sm">${t('channels.enabled_label')}</span>
                     </label>
                 </div>
                 <div class="modal-action">

--- a/src/meshcore_hub/web/static/js/spa/pages/channels.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/channels.js
@@ -1,6 +1,6 @@
 import { apiGet, apiPost, apiPut, apiDelete, isAbortError } from '../api.js';
 import { html, litRender, nothing, t, errorAlert, getConfig, hasRole } from '../components.js';
-import { iconChannel, iconPlus, iconEdit, iconTrash, iconLock } from '../icons.js';
+import { iconChannel, iconPlus, iconEdit, iconTrash } from '../icons.js';
 
 const VISIBILITY_ORDER = ['community', 'member', 'operator', 'admin'];
 
@@ -70,19 +70,19 @@ function renderChannelModal({ channel, isEdit, onSave, onCancel }) {
             <form @submit=${(e) => { e.preventDefault(); onSave(); }}>
                 <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 items-center mb-4">
                     <label class="text-sm opacity-70 text-right">${t('channels.name_label')}</label>
-                    <input type="text" id="channel-modal-name" class="input input-bordered input-sm"
+                    <input type="text" id="channel-modal-name" class="input input-sm"
                         .value=${isEdit ? channel.name : ''}
                         ?disabled=${isEdit}
                         placeholder="${t('channels.name_label')}"
                         required maxlength="100" />
                     ${!isEdit ? html`
                     <label class="text-sm opacity-70 text-right">${t('channels.key_label')}</label>
-                    <input type="text" id="channel-modal-key" class="input input-bordered input-sm font-mono"
+                    <input type="text" id="channel-modal-key" class="input input-sm font-mono"
                         placeholder="e.g. ABCDEF0123456789..."
                         required minlength="32" maxlength="64"
                         pattern="[0-9A-Fa-f]{32,64}" />` : nothing}
                     <label class="text-sm opacity-70 text-right">${t('channels.visibility_label')}</label>
-                    <select id="channel-modal-visibility" class="select select-bordered select-sm">
+                    <select id="channel-modal-visibility" class="select select-sm">
                         <option value="community" .selected=${channel?.visibility === 'community' || !channel}>community</option>
                         <option value="member" .selected=${channel?.visibility === 'member'}>member</option>
                         <option value="operator" .selected=${channel?.visibility === 'operator'}>operator</option>

--- a/src/meshcore_hub/web/static/js/spa/pages/home.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/home.js
@@ -58,8 +58,8 @@ function renderHeroSection({ networkName, logoUrl, logoInvertLight, networkCity,
         : nothing;
 
     const welcomeText = networkWelcomeText
-        ? html`<p class="py-4 max-w-[70%]">${networkWelcomeText}</p>`
-        : html`<p class="py-4 max-w-[70%]">
+        ? html`<p class="py-4 max-w-[90%] sm:max-w-[70%]">${networkWelcomeText}</p>`
+        : html`<p class="py-4 max-w-[90%] sm:max-w-[70%]">
             ${t('home.welcome_default', { network_name: networkName })}
         </p>`;
 

--- a/src/meshcore_hub/web/static/js/spa/pages/maintenance.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/maintenance.js
@@ -20,7 +20,7 @@ export async function render(container, params, router) {
             <img src=${config.logo_url} alt=${config.network_name} class="${logoClass} h-16 w-16" />
             <h1 class="text-3xl font-bold">${config.network_name}</h1>
             <h2 class="text-xl font-semibold text-warning">${t('maintenance.title')}</h2>
-            <p class="text-base-content/70">${t('maintenance.message')}</p>
+            <p class="opacity-70">${t('maintenance.message')}</p>
         </div>
     </div>
 </div>`, container);

--- a/src/meshcore_hub/web/static/js/spa/pages/map.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/map.js
@@ -50,8 +50,8 @@ function createNodeIcon(node, oidcEnabled) {
     const timeDisplay = relativeTime ? ' (' + relativeTime + ')' : '';
 
     const iconHtml = (oidcEnabled && node.is_adopted)
-        ? '<div style="width: 12px; height: 12px; background: #3b82f6; border: 2px solid #1e40af; border-radius: 50%; box-shadow: 0 0 4px rgba(59,130,246,0.6), 0 1px 2px rgba(0,0,0,0.5);"></div>'
-        : '<div style="width: 12px; height: 12px; background: #22c55e; border: 2px solid #15803d; border-radius: 50%; box-shadow: 0 0 4px rgba(34,197,94,0.6), 0 1px 2px rgba(0,0,0,0.5);"></div>';
+        ? '<div style="width: 12px; height: 12px; background: var(--color-marker-infra); border: 2px solid var(--color-marker-infra-border); border-radius: 50%; box-shadow: 0 0 4px rgba(59,130,246,0.6), 0 1px 2px rgba(0,0,0,0.5);"></div>'
+        : '<div style="width: 12px; height: 12px; background: var(--color-marker-public); border: 2px solid var(--color-marker-public-border); border-radius: 50%; box-shadow: 0 0 4px rgba(34,197,94,0.6), 0 1px 2px rgba(0,0,0,0.5);"></div>';
 
     return L.divIcon({
         className: 'custom-div-icon',
@@ -72,8 +72,8 @@ function createPopupContent(node, oidcEnabled) {
 
     let infraIndicatorHtml = '';
     if (oidcEnabled && typeof node.is_adopted !== 'undefined') {
-        const dotColor = node.is_adopted ? '#3b82f6' : '#22c55e';
-        const borderColor = node.is_adopted ? '#1e40af' : '#15803d';
+        const dotColor = node.is_adopted ? 'var(--color-marker-infra)' : 'var(--color-marker-public)';
+        const borderColor = node.is_adopted ? 'var(--color-marker-infra-border)' : 'var(--color-marker-public-border)';
         const title = node.is_adopted ? ((window.t && window.t('map.infrastructure')) || 'Infrastructure') : ((window.t && window.t('map.public')) || 'Public');
         infraIndicatorHtml = ' <span style="display: inline-block; width: 10px; height: 10px; background: ' + dotColor + '; border: 2px solid ' + borderColor + '; border-radius: 50%; vertical-align: middle;" title="' + title + '"></span>';
     }
@@ -206,14 +206,14 @@ export async function render(container, params, router) {
         <div class="flex gap-4 flex-wrap items-end">
             <div class="fieldset">
                 <label class="fieldset-label">${t('common.show')}</label>
-                <select id="filter-category" class="select select-bordered select-sm" @change=${applyFilters}>
+                <select id="filter-category" class="select select-sm" @change=${applyFilters}>
                     <option value="">${t('common.all_entity', { entity: t('entities.nodes') })}</option>
                     ${config.oidc_enabled ? html`<option value="infra">${t('map.infrastructure_only')}</option>` : nothing}
                 </select>
             </div>
             <div class="fieldset">
                 <label class="fieldset-label">${t('common.node_type')}</label>
-                <select id="filter-type" class="select select-bordered select-sm" @change=${applyFilters}>
+                <select id="filter-type" class="select select-sm" @change=${applyFilters}>
                     <option value="">${t('common.all_types')}</option>
                     <option value="chat">${t('node_types.chat')}</option>
                     <option value="repeater">${t('node_types.repeater')}</option>
@@ -223,7 +223,7 @@ export async function render(container, params, router) {
             ${config.oidc_enabled && operatorProfiles.length > 0 ? html`
             <div class="fieldset">
                 <label class="fieldset-label">${t('common.filter_operator_label')}</label>
-                <select id="member-filter" class="select select-bordered select-sm" @change=${applyFilters}>
+                <select id="member-filter" class="select select-sm" @change=${applyFilters}>
                     <option value="">${t('common.all_operators')}</option>
                     ${operatorProfiles.sort((a, b) => {
                         const na = a.name || a.callsign || '';
@@ -255,11 +255,11 @@ ${config.oidc_enabled ? html`
 <div class="mt-4 flex flex-wrap gap-4 items-center text-sm">
     <span class="opacity-70">${t('map.legend')}</span>
     <div class="flex items-center gap-1">
-        <div style="width: 10px; height: 10px; background: #3b82f6; border: 2px solid #1e40af; border-radius: 50%;"></div>
+        <div style="width: 10px; height: 10px; background: var(--color-marker-infra); border: 2px solid var(--color-marker-infra-border); border-radius: 50%;"></div>
         <span>${t('map.infrastructure')}</span>
     </div>
     <div class="flex items-center gap-1">
-        <div style="width: 10px; height: 10px; background: #22c55e; border: 2px solid #15803d; border-radius: 50%;"></div>
+        <div style="width: 10px; height: 10px; background: var(--color-marker-public); border: 2px solid var(--color-marker-public-border); border-radius: 50%;"></div>
         <span>${t('map.public')}</span>
     </div>
 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/members.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/members.js
@@ -25,7 +25,9 @@ function renderProfileTile(profile, router) {
                 e.stopPropagation();
                 router.navigate('/nodes/' + node.public_key);
             };
-            return html`<span class="badge badge-secondary badge-sm cursor-pointer" @click=${handleClick}>${label}</span>`;
+            return html`<span class="badge badge-secondary badge-sm cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary" role="button" tabindex="0"
+                @click=${handleClick}
+                @keydown=${(e) => { if (e.key === 'Enter' || e.key === ' ') handleClick(e); }}>${label}</span>`;
         })}</div>`
         : nothing;
 
@@ -33,8 +35,11 @@ function renderProfileTile(profile, router) {
         ? html`<p class="text-sm opacity-70 mt-1 truncate">${profile.description}</p>`
         : nothing;
 
+    const openUrl = (e) => { e.preventDefault(); e.stopPropagation(); window.open(profile.url, '_blank', 'noopener,noreferrer'); };
     const urlLink = profile.url
-        ? html`<span class="link link-accent text-xs mt-1 inline-block truncate cursor-pointer" @click=${(e) => { e.preventDefault(); e.stopPropagation(); window.open(profile.url, '_blank', 'noopener,noreferrer'); }}>${profile.url}</span>`
+        ? html`<span class="link link-accent text-xs mt-1 inline-block truncate cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary" role="link" tabindex="0"
+            @click=${openUrl}
+            @keydown=${(e) => { if (e.key === 'Enter') openUrl(e); }}>${profile.url}</span>`
         : nothing;
 
     return html`<a href="/profile/${profile.id}" class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">

--- a/src/meshcore_hub/web/static/js/spa/pages/members.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/members.js
@@ -83,7 +83,7 @@ export async function render(container, params, router) {
     <h1 class="text-3xl font-bold">${t('entities.members')}</h1>
 </div>
 
-<div class="text-center py-12 opacity-70">
+<div class="text-center py-8 opacity-70">
     <p class="text-lg">${t('members_page.empty_state')}</p>
     <p class="text-sm mt-2">${t('members_page.empty_description')}</p>
 </div>`, container);

--- a/src/meshcore_hub/web/static/js/spa/pages/messages.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/messages.js
@@ -386,7 +386,7 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.type')}</span>
                 </label>
-                <select name="message_type" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="message_type" class="select select-sm" @change=${autoSubmit}>
                     <option value="">${t('common.all_types')}</option>
                     <option value="contact" ?selected=${message_type === 'contact'}>${t('messages.type_direct')}</option>
                     <option value="channel" ?selected=${message_type === 'channel'}>${t('messages.type_channel')}</option>
@@ -397,7 +397,7 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('entities.channel')}</span>
                 </label>
-                <select name="channel_idx" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="channel_idx" class="select select-sm" @change=${autoSubmit}>
                     <option value="">${t('common.all_channels')}</option>
                     ${builtinLabels.size > 0 ? html`<optgroup label=${t('channels.optgroup_standard')}>${[...builtinLabels.entries()].map(([idx, label]) =>
                         html`<option value=${idx} ?selected=${channel_idx === String(idx)}>${label}</option>`
@@ -466,7 +466,7 @@ ${observerBadges('flex lg:hidden mb-4')}
     ${mobileCards}
 </div>
 
-<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow">
+<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow-sm">
     <table class="table table-zebra">
         <thead>
             <tr>

--- a/src/meshcore_hub/web/static/js/spa/pages/messages.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/messages.js
@@ -218,7 +218,7 @@ export async function render(container, params, router) {
         const displayContent = error ? lastContent : content;
         const displayTotal = error ? lastTotal : total;
         litRender(html`
-<div class="flex items-center justify-between mb-4">
+<div class="flex items-center justify-between mb-6">
     <h1 class="text-3xl font-bold">${t('entities.messages')}</h1>
     ${tzBadge}
 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
@@ -49,12 +49,12 @@ function renderEditTagModal() {
             <input type="hidden" id="tagEditKey">
             <div class="fieldset mb-4">
                 <label class="fieldset-label">${t('common.value')}</label>
-                <input type="text" id="tagEditValue" class="input input-bordered w-full">
+                <input type="text" id="tagEditValue" class="input w-full">
                 <div class="hidden text-xs text-error" id="tagEditError"></div>
             </div>
             <div class="fieldset mb-4">
                 <label class="fieldset-label">${t('common.type')}</label>
-                <select id="tagEditType" class="select select-bordered w-full">
+                <select id="tagEditType" class="select w-full">
                     <option value="string">string</option>
                     <option value="number">number</option>
                     <option value="boolean">boolean</option>
@@ -227,13 +227,13 @@ export async function render(container, params, router) {
             ? html`<form id="tag-add-form" class="mt-4">
                 <div class="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto_auto] gap-2 items-end">
                     <div class="fieldset">
-                        <input type="text" name="key" class="input input-bordered input-sm w-full" placeholder=${t('common.key')} required>
+                        <input type="text" name="key" class="input input-sm w-full" placeholder=${t('common.key')} required>
                     </div>
                     <div class="fieldset">
-                        <input type="text" name="value" class="input input-bordered input-sm w-full" placeholder=${t('common.value')}>
+                        <input type="text" name="value" class="input input-sm w-full" placeholder=${t('common.value')}>
                         <div class="hidden text-xs text-error" id="tagAddError"></div>
                     </div>
-                    <select name="value_type" class="select select-bordered select-sm w-28">
+                    <select name="value_type" class="select select-sm w-28">
                         <option value="string">string</option>
                         <option value="number">number</option>
                         <option value="boolean">boolean</option>
@@ -297,7 +297,7 @@ export async function render(container, params, router) {
     <span class="text-6xl flex-shrink-0" title=${node.adv_type || t('node_types.unknown')}>${emoji}</span>
     <div class="flex-1 min-w-0">
         <h1 class="text-3xl font-bold">${displayName}</h1>
-        ${tagDescription ? html`<p class="text-base-content/70 mt-2">${tagDescription}</p>` : nothing}
+        ${tagDescription ? html`<p class="opacity-70 mt-2">${tagDescription}</p>` : nothing}
     </div>
 </div>
 

--- a/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/node-detail.js
@@ -116,13 +116,13 @@ export async function render(container, params, router) {
 <div class="relative rounded-box overflow-hidden mb-6 shadow-xl" style="height: 180px;">
     <div id="header-map" class="absolute inset-0 z-0"></div>
     <div class="relative z-20 h-full p-3 flex items-center justify-end">
-        <div id="qr-code" class="bg-white p-2 rounded shadow-lg"></div>
+        <div id="qr-code" class="bg-white p-2 rounded-box shadow-lg"></div>
     </div>
 </div>`
             : html`
 <div class="card bg-base-100 shadow-xl mb-6">
     <div class="card-body flex-row items-center gap-4">
-        <div id="qr-code" class="bg-white p-1 rounded"></div>
+        <div id="qr-code" class="bg-white p-2 rounded-box"></div>
         <p class="text-sm opacity-70">${t('nodes.scan_to_add')}</p>
     </div>
 </div>`;

--- a/src/meshcore_hub/web/static/js/spa/pages/nodes.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/nodes.js
@@ -37,7 +37,7 @@ export async function render(container, params, router) {
         const displayContent = error ? lastContent : content;
         const displayTotal = error ? lastTotal : total;
         litRender(html`
-<div class="flex items-center justify-between mb-4">
+<div class="flex items-center justify-between mb-6">
     <h1 class="text-3xl font-bold">${t('entities.nodes')}</h1>
     ${tzBadge}
 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/nodes.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/nodes.js
@@ -136,14 +136,14 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.search')}</span>
                 </label>
-                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-bordered input-sm w-80" @keydown=${submitOnEnter} />
+                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-sm w-80" @keydown=${submitOnEnter} />
             </div>`,
                 () => html`
             <div class="flex flex-col gap-1">
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.type')}</span>
                 </label>
-                <select name="adv_type" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="adv_type" class="select select-sm" @change=${autoSubmit}>
                     <option value="">${t('common.all_types')}</option>
                     <option value="chat" ?selected=${adv_type === 'chat'}>${t('node_types.chat')}</option>
                     <option value="repeater" ?selected=${adv_type === 'repeater'}>${t('node_types.repeater')}</option>
@@ -158,7 +158,7 @@ ${displayContent}`, container);
                 <label class="flex items-center py-1">
                     <span class="opacity-80 text-sm">${t('common.filter_operator_label')}</span>
                 </label>
-                <select name="adopted_by" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="adopted_by" class="select select-sm" @change=${autoSubmit}>
                     <option value="" ?selected=${!adopted_by}>${t('common.all_operators')}</option>
                     ${profiles.sort((a, b) => {
                         const na = a.name || a.callsign || '';
@@ -210,7 +210,7 @@ ${mobileSortSelect({
     ${mobileCards}
 </div>
 
-<div class="hidden lg:block overflow-x-auto bg-base-100 rounded-box shadow">
+<div class="hidden lg:block overflow-x-auto bg-base-100 rounded-box shadow-sm">
     <table class="table table-zebra">
         <thead>
             <tr>

--- a/src/meshcore_hub/web/static/js/spa/pages/not-found.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/not-found.js
@@ -8,7 +8,7 @@ export async function render(container, params, router) {
         <div class="max-w-md">
             <div class="text-9xl font-bold text-primary opacity-20">404</div>
             <h1 class="text-4xl font-bold -mt-8">${t('common.page_not_found')}</h1>
-            <p class="py-6 text-base-content/70">
+            <p class="py-6 opacity-70">
                 ${t('not_found.description')}
             </p>
             <div class="flex gap-4 justify-center">

--- a/src/meshcore_hub/web/static/js/spa/pages/packet-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packet-detail.js
@@ -85,7 +85,7 @@ ${content}`, container);
 
         shell(html`
 ${redactedNotice}
-<div class="card bg-base-100 shadow">
+<div class="card bg-base-100 shadow-sm">
     <div class="card-body">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8">
             ${field(t('common.time'), formatDateTime(p.received_at))}

--- a/src/meshcore_hub/web/static/js/spa/pages/packet-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packet-detail.js
@@ -29,8 +29,8 @@ export async function render(container, params, router) {
     </ul>
 </div>
 
-<div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-bold">${t('packets.detail_title')}</h1>
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-3xl font-bold">${t('packets.detail_title')}</h1>
     ${tzBadge}
 </div>
 ${content}`, container);

--- a/src/meshcore_hub/web/static/js/spa/pages/packet-group-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packet-group-detail.js
@@ -327,7 +327,7 @@ ${content}`, container);
 
         shell(html`
 ${redactedNotice}
-<div class="card bg-base-100 shadow">
+<div class="card bg-base-100 shadow-sm">
     <div class="card-body">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8">
             ${field(t('common.time'), formatDateTime(g.first_seen))}

--- a/src/meshcore_hub/web/static/js/spa/pages/packet-group-detail.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packet-group-detail.js
@@ -243,8 +243,8 @@ export async function render(container, params, router) {
         <li>${leaf || t('packets.detail_title')}</li>
     </ul>
 </div>
-<div class="flex items-center justify-between mb-4">
-    <h1 class="text-2xl font-bold">${t('packets.detail_title')}</h1>
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-3xl font-bold">${t('packets.detail_title')}</h1>
     ${tzBadge}
 </div>
 ${content}`, container);

--- a/src/meshcore_hub/web/static/js/spa/pages/packets.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packets.js
@@ -152,12 +152,12 @@ ${displayContent}`, container);
                 () => html`
             <div class="flex flex-col gap-1">
                 <label class="flex items-center py-1"><span class="opacity-80 text-sm">${t('common.search')}</span></label>
-                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-bordered input-sm w-80" @keydown=${submitOnEnter} />
+                <input type="text" name="search" .value=${search} placeholder="${t('common.search_placeholder')}" class="input input-sm w-80" @keydown=${submitOnEnter} />
             </div>`,
                 () => html`
             <div class="flex flex-col gap-1 max-w-48">
                 <label class="flex items-center py-1"><span class="opacity-80 text-sm">${t('packets.filter_event_type')}</span></label>
-                <select name="event_type" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="event_type" class="select select-sm" @change=${autoSubmit}>
                     <option value="" ?selected=${!event_type}>${t('common.all_types')}</option>
                     ${EVENT_TYPES.map(et => html`<option value=${et} ?selected=${event_type === et}>${et}</option>`)}
                 </select>
@@ -165,7 +165,7 @@ ${displayContent}`, container);
                 () => html`
             <div class="flex flex-col gap-1 max-w-48">
                 <label class="flex items-center py-1"><span class="opacity-80 text-sm">${t('entities.channel')}</span></label>
-                <select name="channel_idx" class="select select-bordered select-sm" @change=${autoSubmit}>
+                <select name="channel_idx" class="select select-sm" @change=${autoSubmit}>
                     <option value="" ?selected=${channel_idx === ''}>${t('common.all_channels')}</option>
                     ${channelList.map(c => html`<option value=${c.idx} ?selected=${String(channel_idx) === String(c.idx)}>${c.name} (${c.idx})</option>`)}
                 </select>
@@ -208,7 +208,7 @@ ${mobileSortSelect({
     ${mobileCards}
 </div>
 
-<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow">
+<div class="hidden lg:block overflow-x-auto overflow-y-visible bg-base-100 rounded-box shadow-sm">
     <table class="table table-zebra">
         <thead>
             <tr>

--- a/src/meshcore_hub/web/static/js/spa/pages/packets.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/packets.js
@@ -71,7 +71,7 @@ export async function render(container, params, router) {
         const displayContent = error ? lastContent : content;
         const displayTotal = error ? lastTotal : total;
         litRender(html`
-<div class="flex items-center justify-between mb-4">
+<div class="flex items-center justify-between mb-6">
     <h1 class="text-3xl font-bold">${t('entities.packets')}</h1>
     ${tzBadge}
 </div>

--- a/src/meshcore_hub/web/static/js/spa/pages/profile.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/profile.js
@@ -10,7 +10,7 @@ function renderAdoptedNode(node) {
     const relTime = node.last_seen ? formatRelativeTime(node.last_seen) : '-';
     const fullTime = node.last_seen ? formatDateTime(node.last_seen) : '-';
 
-    return html`<a href="/nodes/${node.public_key}" class="flex items-center justify-between gap-3 p-3 bg-base-200 rounded-lg hover:bg-base-300 transition-colors">
+    return html`<a href="/nodes/${node.public_key}" class="flex items-center justify-between gap-3 p-3 bg-base-200 rounded-box hover:bg-base-300 transition-colors">
         <div class="flex-1 min-w-0">
             <div class="font-medium text-sm truncate">${displayName}</div>
             <div class="font-mono text-xs opacity-60 truncate">${node.public_key}</div>

--- a/src/meshcore_hub/web/static/js/spa/pages/profile.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/profile.js
@@ -44,7 +44,7 @@ function renderProfileDetails(profile, config) {
                 <h2 class="card-title">${t('user_profile.adopted_nodes')}</h2>
                 ${profile.nodes && profile.nodes.length > 0
                     ? html`<div class="space-y-2">${profile.nodes.map(n => renderAdoptedNode(n))}</div>`
-                    : html`<p class="text-base-content/60 text-sm py-4">${t('user_profile.no_adopted_nodes')}</p>`}
+                    : html`<p class="opacity-60 text-sm py-4">${t('user_profile.no_adopted_nodes')}</p>`}
             </div>
         </div>`
         : nothing;
@@ -125,25 +125,25 @@ ${flashHtml}
                 <form id="profile-form" class="py-4 space-y-4">
                     <label class="flex items-center gap-3 py-1">
                         <span class="text-sm font-medium shrink-0 w-24">${t('user_profile.name_label')}</span>
-                        <input type="text" name="name" class="input input-bordered flex-1"
+                        <input type="text" name="name" class="input flex-1"
                                value=${profile.name || ''}
                                placeholder=${t('user_profile.name_placeholder')} maxlength="255" />
                     </label>
                     <label class="flex items-center gap-3 py-1">
                         <span class="text-sm font-medium shrink-0 w-24">${t('user_profile.callsign_label')}</span>
-                        <input type="text" name="callsign" class="input input-bordered flex-1"
+                        <input type="text" name="callsign" class="input flex-1"
                                value=${profile.callsign || ''}
                                placeholder=${t('user_profile.callsign_placeholder')} maxlength="20" />
                     </label>
                     <label class="flex items-center gap-3 py-1">
                         <span class="text-sm font-medium shrink-0 w-24">${t('user_profile.description_label')}</span>
-                        <input type="text" name="description" class="input input-bordered flex-1"
+                        <input type="text" name="description" class="input flex-1"
                                value=${profile.description || ''}
                                placeholder=${t('user_profile.description_placeholder')} maxlength="500" />
                     </label>
                     <label class="flex items-center gap-3 py-1">
                         <span class="text-sm font-medium shrink-0 w-24">${t('user_profile.url_label')}</span>
-                        <input type="url" name="url" class="input input-bordered flex-1"
+                        <input type="url" name="url" class="input flex-1"
                                value=${profile.url || ''}
                                placeholder=${t('user_profile.url_placeholder')} maxlength="2048" />
                     </label>
@@ -160,7 +160,7 @@ ${flashHtml}
             <h2 class="card-title">${t('user_profile.adopted_nodes')}</h2>
             ${profile.nodes && profile.nodes.length > 0
                 ? html`<div class="space-y-2">${profile.nodes.map(n => renderAdoptedNode(n))}</div>`
-                : html`<p class="text-base-content/60 text-sm py-4">${t('user_profile.no_adopted_nodes')}</p>`}
+                : html`<p class="opacity-60 text-sm py-4">${t('user_profile.no_adopted_nodes')}</p>`}
         </div>
     </div>` : nothing}
 

--- a/src/meshcore_hub/web/templates/error.html
+++ b/src/meshcore_hub/web/templates/error.html
@@ -23,7 +23,7 @@
         }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
-            font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+            font-family: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
             background: var(--bg);
             color: var(--text);
             min-height: 100vh;

--- a/src/meshcore_hub/web/templates/spa.html
+++ b/src/meshcore_hub/web/templates/spa.html
@@ -37,6 +37,9 @@
     </style>
     {% endif %}
 
+    <!-- Preload primary UI font (URL must match the @font-face src exactly; crossorigin required for fonts) -->
+    <link rel="preload" href="/static/vendor/fonts/ibm-plex-sans-latin-wght-normal.woff2" as="font" type="font/woff2" crossorigin>
+
     <!-- Tailwind CSS with DaisyUI (built from source) -->
     <link rel="stylesheet" href="/static/css/tailwind.css?v={{ version }}" />
 

--- a/tests/test_web/test_caching.py
+++ b/tests/test_web/test_caching.py
@@ -35,6 +35,21 @@ class TestCacheControlHeaders:
             response.headers["cache-control"] == "public, max-age=31536000, immutable"
         )
 
+    def test_static_vendor_font(self, client):
+        """Vendored fonts should have long-term immutable cache.
+
+        Only the header is asserted (not status): static/vendor/ is a build
+        artifact absent from host checkouts, and the middleware sets headers
+        on 404 responses too.
+        """
+        response = client.get(
+            "/static/vendor/fonts/ibm-plex-sans-latin-wght-normal.woff2"
+        )
+        assert "cache-control" in response.headers
+        assert (
+            response.headers["cache-control"] == "public, max-age=31536000, immutable"
+        )
+
     def test_static_css_without_version(self, client):
         """Static CSS without version should have short fallback cache."""
         response = client.get("/static/css/app.css")


### PR DESCRIPTION
## Summary

Cosmetic and typography refresh with no changes to layout, navigation, or overall look and feel. Five commits, reviewable independently:

### Visual bug fixes
- **Channels modal labels rendered unstyled** — the modal still used daisyUI v4's `label-text`, removed in v5 (missed by the earlier migration). Replaced with the Tailwind equivalent.
- **Markdown link hover was near-invisible** — `.prose a:hover` used `--color-primary-content` (the on-primary foreground). Now blends primary toward base-content, working in both themes.

### Zero-visual-delta cleanups
- Removed ~27 no-op `input-bordered`/`select-bordered` classes (daisyUI v5 borders by default) and renamed deprecated bare `shadow` to its byte-identical Tailwind v4 alias `shadow-sm`.
- Hoisted hardcoded map-marker hex colors into named CSS variables (same values; markers stay theme-independent since they sit on map tiles).
- Converged the five `text-base-content/*` outliers onto the dominant `opacity-*` muted-text idiom; removed a dead ternary and an unused import.

### Consistency normalizations
- Page `<h1>`s unified at `text-3xl font-bold`; header rows at `mb-6`; empty states at `py-8 opacity-70`; QR backings and adopted-node rows on the `rounded-box` theme radius.
- Home hero welcome text no longer wraps into a skinny column on narrow screens (`max-w-[90%] sm:max-w-[70%]`; desktop unchanged).
- Styling conventions documented in the `components.js` header to prevent future drift.

### Keyboard accessibility
- The clickable channel cards, member node badges, and member URL text were plain divs/spans unreachable by keyboard. Added role/tabindex, Enter/Space handling, and focus-visible outlines (invisible to mouse users).

### Typography: self-hosted IBM Plex
- **IBM Plex Sans** (variable 100–700) app-wide via Tailwind v4 `@theme --font-sans`; **IBM Plex Mono 400** for all `font-mono` data (public keys, packet hashes, hex).
- Self-hosted from @fontsource through the existing `build.js` vendor pipeline — no CDN. Latin + latin-ext subsets only (en/nl locales), ~105 KB total; a typical English page fetches ~60 KB (latin sans preloaded + mono on demand via unicode-range).
- Chart.js default font matched; standalone error page name-prepends Plex without taking on asset dependencies; `/static/vendor/fonts/` gets a long-term immutable cache header with a covering test.

## Test plan

- [x] `pytest -nauto --no-cov tests/test_web/` — 236 passed (includes new font cache-header test)
- [x] `pre-commit run --all-files` — clean
- [x] `make build && make up` — Docker build validates @fontsource file paths (`vendor()` hard-fails on wrong names); verified fonts serve with `font/woff2` + `public, max-age=31536000, immutable`, built CSS wires `default-font-family: var(--font-sans)`, preload tag present
- [x] Eyeballed dark/light themes: channels modal labels, prose link hover, dashboard stat cards, list-page tables at desktop/mobile widths, map markers + legend, node-detail QR panels, home hero at narrow viewport
- [x] Sanity grep: zero remaining `label-text` / `input-bordered` / `select-bordered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)