### PR TITLE
fix(web): stop closed mobile nav from intercepting page clicks

### DIFF
--- a/src/meshcore_hub/web/static/css/app.css
+++ b/src/meshcore_hub/web/static/css/app.css
@@ -424,7 +424,8 @@
         font-size: 0.9375rem;
     }
 
-    #mobile-nav {
+    .dropdown.dropdown-open #mobile-nav,
+    .dropdown:focus-within #mobile-nav {
         display: block;
         column-count: 2;
         column-gap: 0.25rem;


### PR DESCRIPTION
## Problem

The new two-column mobile navigation menu had a z-index/click-through bug: when the menu was **closed**, clicking on page content in the area where the menu *would* appear triggered the hidden nav links and fired SPA navigation. Nav links were active even though the menu was invisible.

## Root cause

Commit 479c263 added two-column layout to `#mobile-nav`:

```css
#mobile-nav {
    display: block;        /* forced to override .menu { display: flex } */
    column-count: 2;
    column-gap: 0.25rem;
    width: min(90vw, 20rem);
}
``"

`display: block` was needed because DaisyUI's `.menu` is `display: flex` (multicol is ignored on flex containers). But `#mobile-nav` is an **ID selector** (specificity `1,0,0`), which beats DaisyUI's closed-state rule:

```css
.dropdown:not(details,.dropdown-open,.dropdown-hover:hover,:focus-within) .dropdown-content { display: none } /* 0,4,0 */
``"

So the menu stayed `display: block` even when "closed" — DaisyUI only dropped it to `opacity: 0`. The invisible, now up-to-20rem-wide two-column overlay kept capturing clicks over the page beneath and firing `data-nav-link` navigation.

## Fix

Scope the `display: block` (and the two-column layout) to the dropdown's **open state** only, so DaisyUI's `display: none` can hide the menu — and its links — when closed:

```css
.dropdown.dropdown-open #mobile-nav,
.dropdown:focus-within #mobile-nav {
    display: block;
    column-count: 2;
    column-gap: 0.25rem;
    width: min(90vw, 20rem);
}
``"

- **Closed:** no rule forces `display: block` → DaisyUI `display: none` (`0,4,0`) beats `.menu` flex → menu fully removed from the render tree, links inert.
- **Open:** `.dropdown:focus-within #mobile-nav` (`1,2,0`) beats `.menu` flex → `display: block` + `column-count: 2` works.
- DaisyUI's `allow-discrete` display transition retains `block` during the 0.2s close fade, so no column-reflow flicker.

## Verification

No build step required — `app.css` is served directly. On mobile (≤1023px) with the hamburger menu **closed**, clicks in the menu's footprint now pass through to page content. Opening the menu still renders the two-column layout.

## Checklist

- [x] Change is scoped to the mobile (`max-width: 1023px`) media query where the bug exists
- [x] No JS / template changes
- [x] pre-commit hooks pass