### PR TITLE
feat: add packet breakdown charts to dashboard

### DIFF
--- a/docs/plans/20260704-1429-packet-breakdown-charts/plan.md
+++ b/docs/plans/20260704-1429-packet-breakdown-charts/plan.md
@@ -1,0 +1,421 @@
+# Dashboard Packet Breakdown Charts
+
+## Summary
+
+Add two new chart cards to the Dashboard page, both gated behind the existing
+`packets` feature flag (alongside today's daily "Packets received" line chart),
+that visualize the **composition** of raw packet volume over the last 7 days
+rather than its day-by-day trend:
+
+1. **Packet Event Type** — a horizontal 100% stacked bar showing the share of each
+   `event_type` value (`advertisement`, `channel_msg_recv`, `req`, `ack`, …),
+   rendered as the top 6 buckets with the long tail rolled into an "other"
+   segment.
+2. **Path Hash Width** — a horizontal 100% stacked bar showing the share of the
+   three known path-hash byte widths (`1b` / `2b` / `3b`), explicitly **excluding
+   unavailable (NULL)** widths.
+
+Both charts are driven by a single new aggregation endpoint,
+`GET /api/v1/dashboard/packet-breakdown?days=7`, returning pre-bucketed counts
+that the frontend normalizes into percentages and renders via Chart.js v4's
+horizontal stacked-bar mode (`type: 'bar'`, `indexAxis: 'y'`, `stacked: true`).
+
+## Background & Motivation
+
+The dashboard's Packets card (shipped in `20260703-1330-dashboard-packets-widget`)
+shows only **volume over time** — a 7-day daily line chart and a `packets_7d`
+headline number. It tells the operator *how much* traffic is flowing but nothing
+about *what kind*. On a busy mesh, raw-packet volume is often the highest-signal
+feed, and the two composition questions operators ask most are:
+
+- **What mix of packet types am I seeing?** (advertisements vs. channel messages
+  vs. req/ack/control traffic vs. undecryptable noise). The `event_type` column
+  on `RawPacket` already encodes this at ingest (see
+  `collector/letsmesh_normalizer.py`), but it is surfaced only as a row-level
+  field and a list filter on `/packets` — never aggregated.
+- **How wide are the path-hash prefixes on air?** The `path_hash_bytes` column
+  (persisted in `20260703-2338-path-hash-bytes-filter`) records the widest
+  path-hash prefix width (1/2/3 bytes) per reception. Its distribution is a
+  direct proxy for the on-air mix of short vs. long mesh routes, but today it is
+  only filterable on the `/packets` list page — never summarized.
+
+Both columns are already indexed and queryable; the gap is purely that **no
+endpoint returns counts grouped by these dimensions**, and **no dashboard chart
+visualizes them**. This plan closes that gap with one endpoint and two charts,
+reusing the entire Packets feature-flag scaffolding (flag, color, icon, gating
+idiom) that already exists.
+
+Recent git history shows sustained dashboard/UI polish work
+(`5dbf069` path popover scroll, `f3a2fe7` mobile landscape grid, `c029eae`
+`path_hash_bytes` column, `215690f` packets widget) — this plan continues that
+direction by deepening the Packets card from a single trend line into a
+three-panel composition view.
+
+## Goals
+
+- Add a `GET /api/v1/dashboard/packet-breakdown` endpoint that returns 7-day
+  counts bucketed by `event_type` (top 6 + "other") and by `path_hash_bytes`
+  (1b/2b/3b, NULL excluded), cached and gated consistently with the existing
+  `/packet-activity` endpoint.
+- Add a reusable Chart.js horizontal 100% stacked-bar chart helper to
+  `charts.js`, with a percentage axis and raw-count tooltips.
+- Render two new dashboard chart cards ("Packet event types" and "Path hash
+  width"), visible only when `features.packets !== false`, laid out in a new
+  2-column grid row below the existing 4-card trend grid.
+- Reuse all existing Packets feature-flag plumbing — no new flags, colors,
+  icons, or migrations.
+
+## Non-Goals
+
+- No changes to the `/packets` browse page, `/packet-groups` endpoint, or any
+  list/detail payload schema. The new endpoint is read-only aggregation.
+- No new database migration, model column, or index — reads only from existing
+  `raw_packets.event_type` and `raw_packets.path_hash_bytes` columns.
+- No new feature flag or config variable. The `feature_packets` flag (default
+  `True`) gates both charts exactly as it gates the daily Packets line chart.
+- No role/channel-visibility filtering on the breakdown counts — consistent with
+  `/packet-activity` (observer-level volume metric; payload redaction stays on
+  list/detail endpoints).
+- No per-day / trend version of the breakdowns (single 7-day snapshot only).
+- No SCHEMAS.md update (the new endpoint is dashboard-internal; documented via
+  its OpenAPI summary, as `/packet-activity` is).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-1** — `GET /api/v1/dashboard/packet-breakdown?days=7` returns a
+  `PacketBreakdown` payload:
+  ```json
+  {
+    "days": 7,
+    "by_event_type": [{"label": "advertisement", "count": 1234}, …, {"label": "other", "count": 56}],
+    "by_path_width": [{"label": "1b", "count": 100}, {"label": "2b", "count": 200}, {"label": "3b", "count": 50}]
+  }
+  ```
+- **FR-2** — `by_event_type` contains the **top 6** `event_type` values by count
+  descending, plus a final `{"label": "other", "count": <sum>}` bucket rolling
+  up all remaining values (including any NULL `event_type`). If the distinct
+  value count is ≤ 6, no "other" bucket is emitted. Buckets with zero total
+  produce an empty `by_event_type` list (and the frontend renders nothing).
+- **FR-3** — `by_path_width` always contains exactly three buckets in fixed
+  order — `1b`, `2b`, `3b` — zero-filling any width absent in the window. Rows
+  with `path_hash_bytes IS NULL` are **excluded** from every bucket and from the
+  percentage denominator (honoring the "not unavailable" requirement).
+- **FR-4** — The endpoint is Redis-cached under `dashboard/packet-breakdown`
+  with `redis_cache_ttl_dashboard`, role-independent (default cache key), and
+  guarded by `RequireRead` — identical caching/guard posture to
+  `/packet-activity`.
+- **FR-5** — `days` defaults to 7 and is capped at 90, and the window **excludes
+  today** (the incomplete day), matching `/packet-activity` semantics exactly.
+- **FR-6** — When `features.packets !== false`, the dashboard renders two
+  additional chart cards below the existing trend grid: "Packet event types"
+  (`#packetEventTypeChart`) and "Path hash width" (`#packetPathWidthChart`),
+  each in a 2-column grid (`lg:grid-cols-2`, single column on small screens).
+- **FR-7** — When `features.packets === false`, neither card is rendered, the
+  breakdown endpoint is not fetched, and the existing trend grid layout is
+  unchanged.
+- **FR-8** — Both new charts render as horizontal 100% stacked bars: segments
+  sized proportionally to `count / total * 100`, a `0–100%` x-axis, and
+  tooltips showing the raw count (and percentage) for the hovered segment.
+- **FR-9** — Each card header follows the existing Packets card idiom: entity
+  icon, title, subtitle ("last 7 days"), and a headline number in the entity
+  accent color. Headline for event-type card = sum of all `by_event_type`
+  counts (total packets in window, excluding NULLs in the "other" bucket but
+  including the "other" total); headline for path-width card = sum of all
+  `by_path_width` counts (packets with a known width, i.e. the percentage
+  denominator). Both totals are computed from the breakdown response and
+  passed to `renderChartCards` alongside `stats`.
+- **FR-10** — Empty breakdown (zero packets in window) renders gracefully: the
+  cards still appear with their headline showing `0`, and the canvas is left
+  blank (the chart helper returns `null`, matching `createLineChart`'s
+  empty-data early return at `charts.js:144-146`).
+
+### Technical Requirements
+
+- **TR-1** — New Pydantic schemas in `common/schemas/messages.py` (alongside
+  `DailyActivity`):
+  ```python
+  class BreakdownBucket(BaseModel):
+      label: str
+      count: int
+
+  class PacketBreakdown(BaseModel):
+      days: int
+      by_event_type: list[BreakdownBucket]
+      by_path_width: list[BreakdownBucket]
+  ```
+- **TR-2** — New endpoint in `api/routes/dashboard.py`, placed immediately after
+  `get_packet_activity` (line 432). Signature and decorators mirror
+  `get_packet_activity` exactly:
+  ```python
+  @router.get("/packet-breakdown", response_model=PacketBreakdown)
+  @cached("dashboard/packet-breakdown", ttl_setting="redis_cache_ttl_dashboard")
+  def get_packet_breakdown(
+      _: RequireRead,
+      session: DbSession,
+      request: Request,
+      days: int = 7,
+  ) -> PacketBreakdown:
+      ...
+  ```
+  Body reuses the same date-window math (`days = min(days, 90)`,
+  `end_date = today at 00:00 UTC`, `start_date = end_date - timedelta(days=days)`,
+  `received_at >= start_date AND received_at < end_date`).
+- **TR-3** — Event-type query (single statement):
+  ```python
+  select(RawPacket.event_type, func.count().label("count"))
+  .where(received_at in window)
+  .group_by(RawPacket.event_type)
+  .order_by(func.count().desc())
+  ```
+  Python then takes the first 6 rows verbatim and sums the remainder (including
+  a NULL `event_type` group, if present) into one `{"label": "other", ...}`
+  bucket. When the row count is ≤ 6, "other" is omitted.
+- **TR-4** — Path-width query (single statement):
+  ```python
+  select(RawPacket.path_hash_bytes, func.count().label("count"))
+  .where(received_at in window)
+  .where(RawPacket.path_hash_bytes.isnot(None))
+  .group_by(RawPacket.path_hash_bytes)
+  ```
+  Python maps the returned rows into a fixed `[(1, "1b"), (2, "2b"), (3, "3b")]`
+  order, zero-filling any missing width. This guarantees a stable legend/order
+  regardless of which widths happen to be present.
+- **TR-5** — No new feature gate at the route layer. The endpoint inherits
+  `RequireRead` only — consistent with `/packet-activity`, which has no extra
+  `feature_packets` guard (the flag is enforced client-side via card visibility
+  and via nav/route registration in `app.js`). If a deployment disables
+  `feature_packets`, the endpoint remains callable directly but is simply never
+  requested by the dashboard.
+- **TR-6** — `charts.js` gains a `createStackedBarChart(canvasId, buckets,
+  colors)` helper (no `options` parameter — builds its own internally, mirroring
+  `createLineChart` which also builds options internally via
+  `createChartOptions`):
+  - `type: 'bar'`, `indexAxis: 'y'`, single y-label.
+  - One dataset per bucket, `backgroundColor: colors[i]`, `borderColor:
+    colors[i]`, `borderWidth: 1`.
+  - Data values pre-normalized to percentages (`count / total * 100`); the
+    chart's own stacking therefore sums to ~100 (floating-point rounding may
+    produce 99.9–100.1; Chart.js stacking tolerates this visually).
+  - Own options object (NOT reusing `createChartOptions` — that is designed for
+    vertical line charts with date-rotated x-axis and `beginAtZero` y-axis):
+    `scales.x.max = 100`, `scales.x.stacked = true`, `scales.y.stacked = true`,
+    x-axis tick callback appends `%`; y-axis ticks hidden (single bar);
+    `interaction.mode = 'nearest'` (since a single stacked bar has one y-tick,
+    the user hovers a specific segment, not an x-position).
+  - Tooltip `label` callback renders `<label>: <count> (<pct>%)` using
+    `formatNumber` (already available at `charts.js:19`) and the raw count
+    stashed on each dataset (e.g. `dataset.rawCount`).
+  - Returns `null` when `buckets` is empty/`null` or `total === 0` (matches the
+    `createLineChart` early-return idiom).
+- **TR-7** — `ChartColors` (`charts.js`) gains a `breakdown` palette: a
+  hardcoded ordered array of 7 distinct hues (top 6 + "other"; "other"
+  rendered `oklch(0.55 0 0)` neutral grey). The path-width chart reuses the
+  first three hues of the same palette. Hardcoded oklch colors are
+  legible in both light and dark themes without adding CSS custom
+  property tokens to `app.css`. The palette lives alongside the existing
+  hardcoded colors (`ChartColors.grid`, `ChartColors.text`, etc.) at
+  `charts.js:47-51`.
+- **TR-8** — `initDashboardCharts` (`charts.js`, line 225) signature is extended
+  with two trailing params (`eventTypeData`, `pathWidthData`). When truthy and
+  non-empty, it calls `createStackedBarChart('packetEventTypeChart', ...)` and
+  `createStackedBarChart('packetPathWidthChart', ...)`. The existing four line
+  charts are untouched.
+- **TR-9** — `dashboard.js` `renderChartCards()` emits a **second grid** after
+  the closing `</div>` of the existing trend grid (line 210), gated on
+  `showPackets`. The function signature is extended to accept a
+  `packetBreakdown` parameter (containing `{by_event_type, by_path_width}`),
+  from which headline totals are computed:
+  ```js
+  const eventTypeTotal = packetBreakdown?.by_event_type?.reduce((s, b) => s + b.count, 0) ?? 0;
+  const pathWidthTotal = packetBreakdown?.by_path_width?.reduce((s, b) => s + b.count, 0) ?? 0;
+  ```
+  ```js
+  ${showPackets ? html`
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+      <div class="card …" style="--panel-color: var(--color-packets)">
+          … headline = ${formatNumber(eventTypeTotal)} …
+          … #packetEventTypeChart …
+      </div>
+      <div class="card …" style="--panel-color: var(--color-packets)">
+          … headline = ${formatNumber(pathWidthTotal)} …
+          … #packetPathWidthChart …
+      </div>
+  </div>` : nothing}
+  ```
+  The existing `gridCols(visibleCount)` logic for the trend grid is unchanged
+  (it still counts only nodes/adverts/messages/packets). Putting the breakdowns
+  in their own 2-col row avoids cramming 6 cards into a 4-col grid and gives
+  the composition view its own visual band.
+- **TR-10** — `dashboard.js` `render()`:
+  - Add `/api/v1/dashboard/packet-breakdown?days=7` to the `Promise.all`
+    destructuring (line 224), with `{ signal }` for abort support (same
+    pattern as existing apiGet calls).
+  - After the Promise.all resolves, compute headline totals from the breakdown
+    response and pass `packetBreakdown` to `renderChartCards` so the card
+    headlines can display the correct window totals (see TR-9).
+  - Pass `showPackets ? packetBreakdown.by_event_type : null` and
+    `showPackets ? packetBreakdown.by_path_width : null` as the two new
+    trailing args to `window.initDashboardCharts(...)` (line 267).
+  - Add `'packetEventTypeChart'` and `'packetPathWidthChart'` to the chart
+    cleanup `chartIds` array (line 274–283) so they are destroyed on page
+    unmount alongside the existing four.
+- **TR-11** — i18n keys added to both
+  `src/meshcore_hub/web/static/locales/en.json` and
+  `src/meshcore_hub/web/static/locales/nl.json`, under the existing
+  `entities` and `packets` namespaces:
+  - `entities.packet_event_types` — English: "Packet event types" / Dutch:
+    "Packet gebeurtenistypen"
+  - `entities.path_hash_width` — English: "Path hash width" / Dutch:
+    "Pad-hashbreedte"
+  - `packets.breakdown_other` — English: "Other" / Dutch: "Overig" (the
+    rolled-up tail bucket label; also used as the dataset label so tooltips
+    are localized).
+  - The "last 7 days" subtitle uses `time.last_7_days` (exists in both locales
+    as "Last 7 days" / "Laatste 7 dagen"), since the breakdown is a single
+    7-day snapshot, not a per-day series.
+
+## Implementation Plan
+
+### Phase 1: Backend — breakdown endpoint
+
+- **`common/schemas/messages.py`**: add `BreakdownBucket` and `PacketBreakdown`
+  as specified in TR-1, placed immediately after `DailyActivity` / its point
+  schema.
+- **`api/routes/dashboard.py`**:
+  - `RawPacket` is already imported (added by the packets-widget plan).
+  - Add `get_packet_breakdown` after `get_packet_activity` (line 432) per TR-2.
+  - Implement the two grouped queries (TR-3, TR-4) and the Python
+    top-6 + "other" rollup for event types and the fixed-order zero-fill for
+    path widths.
+  - Reuse the exact date-window math from `get_packet_activity` (TR-2).
+- **Tests** — `tests/test_api/test_dashboard.py`: add a `TestPacketBreakdown`
+  class (or extend the existing dashboard test module). Fixtures:
+  - Seed one observer `Node` and a spread of `RawPacket` rows across the last
+    7 days with: (a) ≥ 8 distinct `event_type` values to exercise the top-6 +
+    "other" rollup (assert the 7th-and-beyond values sum into "other"); (b)
+    rows with `path_hash_bytes` of 1, 2, 3, and NULL (assert NULL is excluded
+    and the denominator reflects only 1+2+3); (c) at least one row dated
+    "today" to assert today is excluded from the window.
+  - Assert response shape, bucket ordering, zero-fill of a missing width, and
+    that the `@cached` key is role-independent (mirror the existing
+    `/packet-activity` test's caching assertion if one exists).
+
+### Phase 2: Frontend — chart helper & palette
+
+- **`charts.js`**:
+  - Add a hardcoded `breakdown` palette to `ChartColors` (TR-7) — an ordered
+    array of 7 oklch hues alongside the existing hardcoded colors (grid, text,
+    etc.).
+  - Add `createStackedBarChart(canvasId, buckets, colors)` per TR-6, building
+    its own options object internally (not reusing `createChartOptions`).
+  - Extend `initDashboardCharts` with the two trailing params and the two new
+    `createStackedBarChart` calls (TR-8).
+- **Manual unit check**: instantiate the helper against a hardcoded bucket
+  array in the browser console (`make up`, then `window.initDashboardCharts`
+  with mock data) to confirm the horizontal stacked bar renders with a 0–100%
+  axis and proportional segments before wiring the dashboard.
+
+### Phase 3: Frontend — dashboard cards & data wiring
+
+- **`spa/pages/dashboard.js`**:
+  - `renderChartCards`: accept a new `packetBreakdown` parameter; compute
+    `eventTypeTotal` and `pathWidthTotal` from it; add the second grid + two
+    cards per TR-9. Both cards reuse `iconPackets`, the `--color-packets`
+    accent, and the established header flex-row idiom.
+  - `render`: extend `Promise.all` destructuring with
+    `apiGet('/api/v1/dashboard/packet-breakdown', { days: 7 }, { signal })`
+    (TR-10); pass `packetBreakdown` to `renderChartCards` for headline
+    computation; pass the two breakdown arrays into `initDashboardCharts`;
+    extend the cleanup array.
+- **i18n**: add the three new keys (TR-11) to
+  `src/meshcore_hub/web/static/locales/en.json` and
+  `src/meshcore_hub/web/static/locales/nl.json`.
+
+### Phase 4: Verify
+
+- `pytest --no-cov tests/test_api/test_dashboard.py tests/test_web/`
+- `pre-commit run --all-files`
+- `make build` (SPA bundle rebuild — must go through the Docker build pipeline;
+  local `node build.js` fails on a missing fontsource asset, per the prior
+  plan's note).
+- `make up`, then visually verify `/dashboard` with `FEATURE_PACKETS=true`:
+  - Trend grid unchanged (4 cards on large screens).
+  - New 2-col row below shows both stacked bars with proportional segments.
+  - Tooltips show raw counts and percentages.
+  - Empty-data path (no packets in window) shows the cards with `0` headline
+    and a blank canvas.
+  - With `FEATURE_PACKETS=false`: neither the trend Packets card nor the new
+    breakdown cards render; the breakdown endpoint is not requested
+    (confirm in the network tab).
+
+## Review
+
+**Status**: Approved with Changes
+
+**Reviewed**: 2026-07-04
+
+### Resolutions
+
+- **Headline data source**: `renderChartCards` accepts a `packetBreakdown`
+  parameter so card headlines can display accurate window totals computed from
+  the breakdown response (sum of all `by_event_type` counts for the event-type
+  card; sum of all `by_path_width` counts for the path-width card).
+- **Color palette**: Hardcoded 7-hue qualitative palette in `ChartColors`
+  within `charts.js` — no new CSS custom property tokens in `app.css`.
+  Hardcoded oklch colors are legible in both light and dark themes.
+- **Locale coverage**: Full translations for both `en.json` and `nl.json`
+  (three new keys each). Dutch values: "Packet gebeurtenistypen",
+  "Pad-hashbreedte", "Overig".
+- **`createStackedBarChart` options**: The helper builds its own options object
+  internally (no `options` parameter) — does NOT reuse the vertical line-chart
+  `createChartOptions` helper. Interaction mode `'nearest'` since the single
+  stacked bar has one y-tick.
+- **i18n file path**: Corrected from `…/js/spa/i18n/locales/` to
+  `src/meshcore_hub/web/static/locales/` (matching `docs/i18n.md`).
+- **Subtitle key**: Uses `time.last_7_days` ("Last 7 days") — the breakdown is
+  a single snapshot, not a per-day series.
+- **Headline number choice**: Count-based (total packets and known-width
+  packets) — consistent with the existing card numeric headline idiom.
+- **Event-type bucket count**: Locked at top 6 + "other" (confirmed in prior
+  Q&A; one-line constant to tune later if needed).
+- **Fetch abort support**: Breakdown apiGet call includes `{ signal }` for
+  request cancellation on page unmount.
+
+### Remaining Action Items
+
+- None — all open questions resolved during review.
+
+## References
+
+- `docs/plans/20260703-1330-dashboard-packets-widget/plan.md` — the dashboard
+  Packets chart this plan extends (trend grid, `initDashboardCharts` signature,
+  `ChartColors.packets`, `renderChartCards` structure, `/packet-activity`
+  endpoint pattern, feature-flag gating idiom).
+- `docs/plans/20260703-2338-path-hash-bytes-filter/plan.md` — persists the
+  `path_hash_bytes` column (1/2/3, NULL when unavailable) that the path-width
+  chart aggregates over; confirms the collector chokepoint and value domain.
+- `docs/plans/20260612-2014-raw-packets-feature/plan.md` — the foundational
+  Raw Packets feature (`RawPacket` model, `event_type` classification,
+  `feature_packets` flag, observer-level volume semantics).
+- `docs/plans/20260616-2023-fix-postgres-charts-flatline/plan.md` —
+  `_date_bucket_key()` dialect-neutral date handling; relevant precedent if the
+  breakdown queries ever need cross-backend date normalization (they currently
+  only filter by `received_at`, not group by date, so this is reference-only).
+- `docs/plans/20260609-2106-redis-api-cache/plan.md` — the `@cached` decorator
+  and `redis_cache_ttl_dashboard` TTL reused by the new endpoint.
+- `src/meshcore_hub/api/routes/dashboard.py:387-432` — `get_packet_activity`,
+  the endpoint whose structure (deps, caching, date window, today-exclusion)
+  the new endpoint mirrors.
+- `src/meshcore_hub/collector/letsmesh_normalizer.py:569-583` —
+  `_FALLBACK_EVENT_TYPES` map documenting the full `event_type` value space
+  (justifies the top-N + "other" rollup).
+- `src/meshcore_hub/web/static/js/charts.js:140-163,225-268` — `createLineChart`
+  and `initDashboardCharts`, the helpers the new chart function sits alongside.
+- `src/meshcore_hub/web/static/js/spa/pages/dashboard.js:114-211,224-283` —
+  `gridCols`, `renderChartCards`, and the `render` data-fetch/init/cleanup flow
+  the plan modifies.
+- Recent commits: `c029eae` (persist `path_hash_bytes`), `215690f` (dashboard
+  packets widget), `f3a2fe7` (mobile landscape chart grid), `5dbf069` (path
+  popover scroll) — the dashboard/UI work this plan continues.

--- a/docs/plans/20260704-1429-packet-breakdown-charts/tasks.md
+++ b/docs/plans/20260704-1429-packet-breakdown-charts/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: Dashboard Packet Breakdown Charts
+
+> Generated from `plan.md` on 2026-07-04
+
+## 1. Backend — Schemas & Endpoint
+
+- [x] 1.1 Add `BreakdownBucket` and `PacketBreakdown` Pydantic schemas
+  - [x] 1.1.1 Add `BreakdownBucket(BaseModel)` with `label: str` and `count: int` in `common/schemas/messages.py`, placed after `DailyActivity`
+  - [x] 1.1.2 Add `PacketBreakdown(BaseModel)` with `days: int`, `by_event_type: list[BreakdownBucket]`, `by_path_width: list[BreakdownBucket]`
+
+- [x] 1.2 Add `GET /api/v1/dashboard/packet-breakdown` endpoint
+  - [x] 1.2.1 Place `get_packet_breakdown` function after `get_packet_activity` (line ~432) in `api/routes/dashboard.py`
+  - [x] 1.2.2 Mirror `get_packet_activity` signature: `RequireRead`, `DbSession`, `request`, `days=7`; decorate with `@cached("dashboard/packet-breakdown", ttl_setting="redis_cache_ttl_dashboard")` and `@router.get` with `response_model=PacketBreakdown`
+  - [x] 1.2.3 Reuse date-window math: `days = min(days, 90)`, `end_date = today at 00:00 UTC`, `start_date = end_date - timedelta(days=days)`, filter `received_at >= start_date AND received_at < end_date`
+
+- [x] 1.3 Implement event-type aggregation (FR-1, FR-2, TR-3)
+  - [x] 1.3.1 Run `select(event_type, func.count())` grouped by `event_type`, ordered by count descending
+  - [x] 1.3.2 Take top 6 rows verbatim; sum remaining rows (including NULL `event_type` group, if present) into `{"label": "other", "count": <sum>}`
+  - [x] 1.3.3 Omit the "other" bucket when distinct event types ≤ 6
+
+- [x] 1.4 Implement path-width aggregation (FR-1, FR-3, TR-4)
+  - [x] 1.4.1 Run `select(path_hash_bytes, func.count())` with `.where(path_hash_bytes.isnot(None))`, grouped by `path_hash_bytes`
+  - [x] 1.4.2 Map rows into fixed `[(1, "1b"), (2, "2b"), (3, "3b")]` order, zero-filling any missing width
+  - [x] 1.4.3 Exclude NULL `path_hash_bytes` from both buckets and percentage denominator
+
+## 2. Backend — Tests
+
+- [x] 2.1 Add `TestPacketBreakdown` class in `tests/test_api/test_dashboard.py`
+  - [x] 2.1.1 Seed one observer `Node` and `RawPacket` rows spanning the last 7 days with ≥ 8 distinct `event_type` values
+  - [x] 2.1.2 Seed rows with `path_hash_bytes` of 1, 2, 3, and NULL
+  - [x] 2.1.3 Seed at least one row dated "today" to verify today is excluded
+
+- [x] 2.2 Test event-type breakdown
+  - [x] 2.2.1 Assert top 6 buckets are correct, descending by count
+  - [x] 2.2.2 Assert 7th-and-beyond values are summed into "other"
+  - [x] 2.2.3 Assert "other" is omitted when distinct event types ≤ 6
+
+- [x] 2.3 Test path-width breakdown
+  - [x] 2.3.1 Assert exactly three buckets in order: 1b, 2b, 3b
+  - [x] 2.3.2 Assert NULL `path_hash_bytes` rows are excluded from all buckets
+  - [x] 2.3.3 Assert missing width is zero-filled (e.g. if no 3b rows exist, count is 0)
+
+- [x] 2.4 Test endpoint behavior
+  - [x] 2.4.1 Assert `response_model` returns correct `PacketBreakdown` shape
+  - [x] 2.4.2 Assert today's rows are excluded from the window
+  - [x] 2.4.3 Assert `days` param is capped at 90
+  - [x] 2.4.4 Assert endpoint returns empty `by_event_type` and `by_path_width` lists when no packets in window (empty-data path)
+  - [x] 2.4.5 Assert role-independent caching behavior (mirror existing `/packet-activity` cache key test)
+
+## 3. Frontend — Chart Helper & Palette
+
+- [x] 3.1 Add `breakdown` color palette to `ChartColors` in `charts.js` (TR-7)
+  - [x] 3.1.1 Define a hardcoded ordered array of 7 oklch hues: 6 distinct event-type colors + 1 neutral grey for "other"
+  - [x] 3.1.2 Place alongside existing hardcoded colors (`ChartColors.grid`, `ChartColors.text`, etc.)
+
+- [x] 3.2 Add `createStackedBarChart` helper in `charts.js` (TR-6)
+  - [x] 3.2.1 Accept `(canvasId, buckets, colors)` — no `options` parameter; builds own options internally
+  - [x] 3.2.2 Return `null` when `buckets` is empty/null or `total === 0` (matches `createLineChart` empty-data idiom)
+  - [x] 3.2.3 Configure chart: `type: 'bar'`, `indexAxis: 'y'`, single y-label, one dataset per bucket with `backgroundColor: colors[i]`, `borderColor: colors[i]`, `borderWidth: 1`
+  - [x] 3.2.4 Pre-normalize data to percentages (`count / total * 100`) so stacked total ~100
+  - [x] 3.2.5 Build options: `scales.x.max = 100`, `scales.x.stacked = true`, `scales.y.stacked = true`, x-axis tick callback appends `%`, y-axis ticks hidden, `interaction.mode = 'nearest'`
+  - [x] 3.2.6 Tooltip `label` callback renders `<label>: <count> (<pct>%)` using `formatNumber` and raw count stashed on dataset (e.g. `dataset.rawCount`)
+
+- [x] 3.3 Extend `initDashboardCharts` in `charts.js` (TR-8)
+  - [x] 3.3.1 Add two trailing params: `eventTypeData`, `pathWidthData`
+  - [x] 3.3.2 When truthy and non-empty, call `createStackedBarChart('packetEventTypeChart', eventTypeData, ChartColors.breakdown)`
+  - [x] 3.3.3 When truthy and non-empty, call `createStackedBarChart('packetPathWidthChart', pathWidthData, ChartColors.breakdown.slice(0, 3))` (reuses first 3 hues)
+
+## 4. Frontend — Dashboard Cards & Data Wiring
+
+- [x] 4.1 Update `renderChartCards` in `spa/pages/dashboard.js` (TR-9)
+  - [x] 4.1.1 Accept new `packetBreakdown` parameter
+  - [x] 4.1.2 Compute `eventTypeTotal` = `.reduce()` sum of `by_event_type` counts (or 0)
+  - [x] 4.1.3 Compute `pathWidthTotal` = `.reduce()` sum of `by_path_width` counts (or 0)
+  - [x] 4.1.4 Emit second grid row after existing trend grid closing `</div>`, gated on `showPackets`
+  - [x] 4.1.5 Build two cards: "Packet event types" with `eventTypeTotal` headline, `#packetEventTypeChart` canvas; "Path hash width" with `pathWidthTotal` headline, `#packetPathWidthChart` canvas
+  - [x] 4.1.6 Reuse `iconPackets`, `--color-packets` accent, and existing header flex-row idiom
+
+- [x] 4.2 Update `render` in `spa/pages/dashboard.js` (TR-10)
+  - [x] 4.2.1 Add `apiGet('/api/v1/dashboard/packet-breakdown', { days: 7 }, { signal })` to the `Promise.all` destructuring
+  - [x] 4.2.2 Pass `packetBreakdown` to `renderChartCards` for headline computation
+  - [x] 4.2.3 Pass `showPackets ? packetBreakdown.by_event_type : null` and `showPackets ? packetBreakdown.by_path_width : null` as trailing args to `window.initDashboardCharts(...)`
+  - [x] 4.2.4 Add `'packetEventTypeChart'` and `'packetPathWidthChart'` to chart cleanup `chartIds` array
+
+- [x] 4.3 Add i18n keys (TR-11)
+  - [x] 4.3.1 Add `entities.packet_event_types` = "Packet event types" to `en.json`
+  - [x] 4.3.2 Add `entities.path_hash_width` = "Path hash width" to `en.json`
+  - [x] 4.3.3 Add `packets.breakdown_other` = "Other" to `en.json`
+  - [x] 4.3.4 Add Dutch translations to `nl.json`: "Packet gebeurtenistypen", "Pad-hashbreedte", "Overig"
+
+## 5. Verification
+
+- [x] 5.1 Run backend tests
+  - [x] 5.1.1 `pytest --no-cov tests/test_api/test_dashboard.py -v` — all `TestPacketBreakdown` tests pass
+
+- [x] 5.2 Run quality checks
+  - [x] 5.2.1 `pre-commit run --all-files` — no lint/format errors
+
+- [ ] 5.3 Build and deploy
+  - [ ] 5.3.1 `make build` — Docker image rebuilds successfully (SPA bundle included)
+  - [ ] 5.3.2 `make up` — stack starts without errors
+
+- [ ] 5.4 Visual verification (`FEATURE_PACKETS=true`)
+  - [ ] 5.4.1 Trend grid unchanged (4 cards on large screens)
+  - [ ] 5.4.2 New 2-col row below with both stacked bars showing proportional segments
+  - [ ] 5.4.3 Tooltips render `<label>: <count> (<pct>%)`
+  - [ ] 5.4.4 Card headlines show correct totals — event-type total and path-width total
+  - [ ] 5.4.5 Empty-data path: cards show `0` headline, blank canvas (no JS error)
+
+- [ ] 5.5 Visual verification (`FEATURE_PACKETS=false`)
+  - [ ] 5.5.1 Neither trend Packets card nor breakdown cards render
+  - [ ] 5.5.2 Breakdown endpoint is not requested (confirm in network tab)

--- a/src/meshcore_hub/api/routes/dashboard.py
+++ b/src/meshcore_hub/api/routes/dashboard.py
@@ -27,12 +27,14 @@ from meshcore_hub.common.models import (
     UserProfile,
 )
 from meshcore_hub.common.schemas.messages import (
+    BreakdownBucket,
     ChannelMessage,
     DailyActivity,
     DailyActivityPoint,
     DashboardStats,
     MessageActivity,
     NodeCountHistory,
+    PacketBreakdown,
     RecentAdvertisement,
 )
 
@@ -430,6 +432,82 @@ def get_packet_activity(
         data.append(DailyActivityPoint(date=date_str, count=count))
 
     return DailyActivity(days=days, data=data)
+
+
+# Max number of distinct event-type buckets shown verbatim; remaining values
+# are rolled into a single "other" bucket so the chart stays legible.
+_PACKET_BREAKDOWN_TOP_N = 6
+
+
+@router.get("/packet-breakdown", response_model=PacketBreakdown)
+@cached("dashboard/packet-breakdown", ttl_setting="redis_cache_ttl_dashboard")
+def get_packet_breakdown(
+    _: RequireRead,
+    session: DbSession,
+    request: Request,
+    days: int = 7,
+) -> PacketBreakdown:
+    """Get raw-packet composition (by event type and path-hash width).
+
+    Args:
+        days: Number of days to include (default 7, max 90)
+
+    Returns:
+        Counts bucketed by event type (top 6 + "other") and by path-hash
+        byte width (1b/2b/3b, NULL excluded) for the period (excluding today).
+    """
+    days = min(days, 90)
+
+    now = datetime.now(timezone.utc)
+    end_date = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    start_date = end_date - timedelta(days=days)
+
+    window_clauses = (
+        RawPacket.received_at >= start_date,
+        RawPacket.received_at < end_date,
+    )
+
+    # Event-type breakdown: top N by count, remainder rolled into "other".
+    event_rows = session.execute(
+        select(RawPacket.event_type, func.count().label("count"))
+        .where(*window_clauses)
+        .group_by(RawPacket.event_type)
+        .order_by(func.count().desc())
+    ).all()
+
+    by_event_type: list[BreakdownBucket] = []
+    other_total = 0
+    for label, count in event_rows[:_PACKET_BREAKDOWN_TOP_N]:
+        by_event_type.append(
+            BreakdownBucket(
+                label=label if label is not None else "unknown", count=count
+            )
+        )
+    if len(event_rows) > _PACKET_BREAKDOWN_TOP_N:
+        for _, count in event_rows[_PACKET_BREAKDOWN_TOP_N:]:
+            other_total += count
+        by_event_type.append(BreakdownBucket(label="other", count=other_total))
+
+    # Path-width breakdown: fixed 1b/2b/3b order, NULL excluded, zero-filled.
+    width_rows = session.execute(
+        select(RawPacket.path_hash_bytes, func.count().label("count"))
+        .where(*window_clauses)
+        .where(RawPacket.path_hash_bytes.isnot(None))
+        .group_by(RawPacket.path_hash_bytes)
+    ).all()
+    width_counts = {row[0]: row[1] for row in width_rows}
+
+    by_path_width = [
+        BreakdownBucket(label="1b", count=width_counts.get(1, 0)),
+        BreakdownBucket(label="2b", count=width_counts.get(2, 0)),
+        BreakdownBucket(label="3b", count=width_counts.get(3, 0)),
+    ]
+
+    return PacketBreakdown(
+        days=days,
+        by_event_type=by_event_type,
+        by_path_width=by_path_width,
+    )
 
 
 @router.get("/message-activity", response_model=MessageActivity)

--- a/src/meshcore_hub/common/schemas/messages.py
+++ b/src/meshcore_hub/common/schemas/messages.py
@@ -323,6 +323,27 @@ class MessageActivity(BaseModel):
     data: list[DailyActivityPoint] = Field(..., description="Daily message counts")
 
 
+class BreakdownBucket(BaseModel):
+    """Schema for a single labeled count bucket in a breakdown."""
+
+    label: str = Field(..., description="Bucket label")
+    count: int = Field(..., description="Count for this bucket")
+
+
+class PacketBreakdown(BaseModel):
+    """Schema for raw-packet composition over a period."""
+
+    days: int = Field(..., description="Number of days in the period")
+    by_event_type: list[BreakdownBucket] = Field(
+        default_factory=list,
+        description="Top event types by count (top 6 + 'other')",
+    )
+    by_path_width: list[BreakdownBucket] = Field(
+        default_factory=list,
+        description="Path-hash byte widths (1b/2b/3b), NULL excluded",
+    )
+
+
 class NodeCountHistory(BaseModel):
     """Schema for node count over time."""
 

--- a/src/meshcore_hub/web/static/js/charts.js
+++ b/src/meshcore_hub/web/static/js/charts.js
@@ -48,7 +48,20 @@ const ChartColors = {
     text: 'oklch(0.7 0 0)',
     tooltipBg: 'oklch(0.25 0 0)',
     tooltipText: 'oklch(0.9 0 0)',
-    tooltipBorder: 'oklch(0.4 0 0)'
+    tooltipBorder: 'oklch(0.4 0 0)',
+
+    // Qualitative palette for stacked breakdown bars (6 hues + neutral grey
+    // for "other"). Hardcoded oklch values render consistently across light
+    // and dark themes without extra CSS tokens.
+    breakdown: [
+        'oklch(0.65 0.24 265)',   // blue
+        'oklch(0.7 0.17 330)',    // magenta
+        'oklch(0.75 0.18 180)',   // teal
+        'oklch(0.72 0.17 145)',   // green
+        'oklch(0.7 0.19 80)',     // yellow-green
+        'oklch(0.65 0.22 25)',    // orange
+        'oklch(0.55 0 0)'        // neutral grey (for "other")
+    ]
 };
 
 /**
@@ -215,14 +228,101 @@ function createActivityChart(canvasId, advertData, messageData) {
 }
 
 /**
- * Initialize dashboard charts (nodes, advertisements, messages, packets).
+ * Create a horizontal 100% stacked bar chart from labeled buckets.
+ *
+ * Each bucket becomes one dataset sized proportionally to its count. The
+ * x-axis is fixed at 0-100% and tooltips show the raw count and percentage.
+ * Returns null when buckets is empty or the total is zero (matching
+ * createLineChart's empty-data idiom).
+ *
+ * @param {string} canvasId - ID of the canvas element
+ * @param {Array|null} buckets - Array of {label, count} objects
+ * @param {Array<string>} colors - Ordered color strings (one per bucket)
+ * @returns {Chart|null}
+ */
+function createStackedBarChart(canvasId, buckets, colors) {
+    var ctx = document.getElementById(canvasId);
+    if (!ctx || !buckets || buckets.length === 0) return null;
+
+    var total = buckets.reduce(function(sum, b) { return sum + b.count; }, 0);
+    if (total === 0) return null;
+
+    var datasets = buckets.map(function(bucket, i) {
+        var pct = (bucket.count / total) * 100;
+        return {
+            label: bucket.label,
+            data: [pct],
+            backgroundColor: colors[i % colors.length],
+            borderColor: colors[i % colors.length],
+            borderWidth: 1,
+            rawCount: bucket.count
+        };
+    });
+
+    return new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: [''],
+            datasets: datasets
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            indexAxis: 'y',
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    backgroundColor: ChartColors.tooltipBg,
+                    titleColor: ChartColors.tooltipText,
+                    bodyColor: ChartColors.tooltipText,
+                    borderColor: ChartColors.tooltipBorder,
+                    borderWidth: 1,
+                    callbacks: {
+                        label: function(ctx) {
+                            var label = ctx.dataset.label || '';
+                            var count = formatNumber(ctx.dataset.rawCount);
+                            var pct = ctx.parsed.x.toFixed(1);
+                            return label + ': ' + count + ' (' + pct + '%)';
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    max: 100,
+                    stacked: true,
+                    grid: { color: ChartColors.grid },
+                    ticks: {
+                        color: ChartColors.text,
+                        callback: function(value) { return value + '%'; }
+                    }
+                },
+                y: {
+                    stacked: true,
+                    grid: { display: false },
+                    ticks: { display: false }
+                }
+            },
+            interaction: {
+                mode: 'nearest',
+                intersect: false
+            }
+        }
+    });
+}
+
+/**
+ * Initialize dashboard charts (nodes, advertisements, messages, packets,
+ * plus optional packet-breakdown stacked bars).
  * Pass null for any data parameter to skip that chart.
  * @param {Object|null} nodeData - Node count data, or null to skip
  * @param {Object|null} advertData - Advertisement data, or null to skip
  * @param {Object|null} messageData - Message data, or null to skip
- * @param {Object|null} packetData - Raw-packet data, or null to skip
+ * @param {Object|null} packetData - Raw-packet trend data, or null to skip
+ * @param {Array|null} [eventTypeData] - Packet event-type breakdown buckets
+ * @param {Array|null} [pathWidthData] - Packet path-width breakdown buckets
  */
-function initDashboardCharts(nodeData, advertData, messageData, packetData) {
+function initDashboardCharts(nodeData, advertData, messageData, packetData, eventTypeData, pathWidthData) {
     if (nodeData) {
         createLineChart(
             'nodeChart',
@@ -264,6 +364,22 @@ function initDashboardCharts(nodeData, advertData, messageData, packetData) {
             ChartColors.packets,
             ChartColors.packetsFill,
             true
+        );
+    }
+
+    if (eventTypeData && eventTypeData.length > 0) {
+        createStackedBarChart(
+            'packetEventTypeChart',
+            eventTypeData,
+            ChartColors.breakdown
+        );
+    }
+
+    if (pathWidthData && pathWidthData.length > 0) {
+        createStackedBarChart(
+            'packetPathWidthChart',
+            pathWidthData,
+            ChartColors.breakdown.slice(0, 3)
         );
     }
 }

--- a/src/meshcore_hub/web/static/js/spa/pages/dashboard.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/dashboard.js
@@ -119,9 +119,13 @@ function gridCols(count) {
     return '';
 }
 
-function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, stats }) {
+function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, stats, packetBreakdown }) {
     const visibleCount = (showNodes ? 1 : 0) + (showAdverts ? 1 : 0) + (showMessages ? 1 : 0) + (showPackets ? 1 : 0);
     if (visibleCount === 0) return nothing;
+
+    const eventTypeTotal = packetBreakdown?.by_event_type?.reduce((s, b) => s + b.count, 0) ?? 0;
+    const pathWidthTotal = packetBreakdown?.by_path_width?.reduce((s, b) => s + b.count, 0) ?? 0;
+
     return html`
 <div class="grid grid-cols-1 ${gridCols(visibleCount)} gap-6 mb-8">
     ${showNodes ? html`
@@ -135,7 +139,7 @@ function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, s
                     </h2>
                     <p class="text-xs opacity-80">${t('time.over_time_last_7_days')}</p>
                 </div>
-                <div class="text-4xl font-bold leading-none" style="color: var(--color-nodes)">
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-nodes)">
                     ${formatNumber(stats.total_nodes)}
                 </div>
             </div>
@@ -156,7 +160,7 @@ function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, s
                     </h2>
                     <p class="text-xs opacity-80">${t('time.per_day_last_7_days')}</p>
                 </div>
-                <div class="text-4xl font-bold leading-none" style="color: var(--color-adverts)">
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-adverts)">
                     ${formatNumber(stats.advertisements_7d)}
                 </div>
             </div>
@@ -177,7 +181,7 @@ function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, s
                     </h2>
                     <p class="text-xs opacity-80">${t('time.per_day_last_7_days')}</p>
                 </div>
-                <div class="text-4xl font-bold leading-none" style="color: var(--color-messages)">
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-messages)">
                     ${formatNumber(stats.messages_7d)}
                 </div>
             </div>
@@ -198,7 +202,7 @@ function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, s
                     </h2>
                     <p class="text-xs opacity-80">${t('time.per_day_last_7_days')}</p>
                 </div>
-                <div class="text-4xl font-bold leading-none" style="color: var(--color-packets)">
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-packets)">
                     ${formatNumber(stats.packets_7d)}
                 </div>
             </div>
@@ -207,7 +211,50 @@ function renderChartCards({ showNodes, showAdverts, showMessages, showPackets, s
             </div>
         </div>
     </div>` : nothing}
-</div>`;
+</div>
+
+${showPackets ? html`
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+    <div class="card bg-base-100 shadow-xl panel-accent" style="--panel-color: var(--color-packets)">
+        <div class="card-body">
+            <div class="flex items-start justify-between gap-2">
+                <div>
+                    <h2 class="card-title text-base">
+                        ${iconPackets('h-5 w-5')}
+                        ${t('entities.packet_event_types')}
+                    </h2>
+                    <p class="text-xs opacity-80">${t('time.last_7_days')}</p>
+                </div>
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-packets)">
+                    ${formatNumber(eventTypeTotal)}
+                </div>
+            </div>
+            <div class="h-32">
+                <canvas id="packetEventTypeChart"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <div class="card bg-base-100 shadow-xl panel-accent" style="--panel-color: var(--color-packets)">
+        <div class="card-body">
+            <div class="flex items-start justify-between gap-2">
+                <div>
+                    <h2 class="card-title text-base">
+                        ${iconPackets('h-5 w-5')}
+                        ${t('entities.path_hash_width')}
+                    </h2>
+                    <p class="text-xs opacity-80">${t('time.last_7_days')}</p>
+                </div>
+                <div class="text-3xl font-bold leading-none" style="color: var(--color-packets)">
+                    ${formatNumber(pathWidthTotal)}
+                </div>
+            </div>
+            <div class="h-32">
+                <canvas id="packetPathWidthChart"></canvas>
+            </div>
+        </div>
+    </div>
+</div>` : nothing}`;
 }
 
 export async function render(container, params, router) {
@@ -221,12 +268,13 @@ export async function render(container, params, router) {
         const showMessages = features.messages !== false;
         const showPackets = features.packets !== false;
 
-        const [stats, advertActivity, messageActivity, nodeCount, packetActivity, channelsData] = await Promise.all([
+        const [stats, advertActivity, messageActivity, nodeCount, packetActivity, packetBreakdown, channelsData] = await Promise.all([
             apiGet('/api/v1/dashboard/stats', {}, { signal }),
             apiGet('/api/v1/dashboard/activity', { days: 7 }, { signal }),
             apiGet('/api/v1/dashboard/message-activity', { days: 7 }, { signal }),
             apiGet('/api/v1/dashboard/node-count', { days: 7 }, { signal }),
             apiGet('/api/v1/dashboard/packet-activity', { days: 7 }, { signal }),
+            apiGet('/api/v1/dashboard/packet-breakdown', { days: 7 }, { signal }),
             apiGet('/api/v1/channels', {}, { signal }),
         ]);
         channelLabels = new Map([
@@ -246,7 +294,7 @@ export async function render(container, params, router) {
 </div>
 
 ${(showNodes || showAdverts || showMessages || showPackets) ? html`
-${renderChartCards({ showNodes, showAdverts, showMessages, showPackets, stats })}` : nothing}
+${renderChartCards({ showNodes, showAdverts, showMessages, showPackets, stats, packetBreakdown })}` : nothing}
 
 ${bottomCount > 0 ? html`
 <div class="grid grid-cols-1 ${bottomGrid} gap-6">
@@ -269,9 +317,11 @@ ${bottomCount > 0 ? html`
             showAdverts ? advertActivity : null,
             showMessages ? messageActivity : null,
             showPackets ? packetActivity : null,
+            showPackets ? packetBreakdown.by_event_type : null,
+            showPackets ? packetBreakdown.by_path_width : null,
         );
 
-        const chartIds = ['nodeChart', 'advertChart', 'messageChart', 'packetChart'];
+        const chartIds = ['nodeChart', 'advertChart', 'messageChart', 'packetChart', 'packetEventTypeChart', 'packetPathWidthChart'];
         return () => {
             chartIds.forEach(id => {
                 const canvas = document.getElementById(id);

--- a/src/meshcore_hub/web/static/locales/en.json
+++ b/src/meshcore_hub/web/static/locales/en.json
@@ -9,6 +9,8 @@
     "advertisement": "Advert",
     "messages": "Messages",
     "packets": "Packets",
+    "packet_event_types": "Packet Types",
+    "path_hash_width": "Path Bytes",
     "message": "Message",
     "packet": "Packet",
     "map": "Map",
@@ -220,6 +222,7 @@
   "packets": {
     "filter_event_type": "Event Type",
     "filter_path_width": "Path Width",
+    "breakdown_other": "Other",
     "filter_min_snr": "Min SNR",
     "filter_max_snr": "Max SNR",
     "redacted": "Restricted",

--- a/src/meshcore_hub/web/static/locales/nl.json
+++ b/src/meshcore_hub/web/static/locales/nl.json
@@ -9,6 +9,8 @@
     "advertisement": "Advertentie",
     "messages": "Berichten",
     "packets": "Pakketten",
+    "packet_event_types": "Pakkettypes",
+    "path_hash_width": "Padbytes",
     "message": "Bericht",
     "packet": "Pakket",
     "map": "Kaart",
@@ -162,6 +164,7 @@
   "packets": {
     "filter_event_type": "Gebeurtenistype",
     "filter_path_width": "Padbreedte",
+    "breakdown_other": "Overig",
     "filter_min_snr": "Min. SNR",
     "filter_max_snr": "Max. SNR",
     "redacted": "Beperkt",

--- a/tests/test_api/test_dashboard.py
+++ b/tests/test_api/test_dashboard.py
@@ -380,6 +380,167 @@ class TestPacketActivity:
         assert all(p["count"] == 0 for p in other_days)
 
 
+class TestPacketBreakdown:
+    """Tests for GET /dashboard/packet-breakdown endpoint."""
+
+    def test_get_packet_breakdown_empty(self, client_no_auth):
+        """Empty database returns empty bucket lists."""
+        response = client_no_auth.get("/api/v1/dashboard/packet-breakdown")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["days"] == 7
+        assert data["by_event_type"] == []
+        assert data["by_path_width"] == [
+            {"label": "1b", "count": 0},
+            {"label": "2b", "count": 0},
+            {"label": "3b", "count": 0},
+        ]
+
+    def test_get_packet_breakdown_custom_days(self, client_no_auth):
+        """Custom days parameter is honored."""
+        response = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=14")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["days"] == 14
+
+    def test_get_packet_breakdown_max_days(self, client_no_auth):
+        """Days parameter is capped at 90."""
+        response = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=365")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["days"] == 90
+
+    def test_breakdown_excludes_today(self, client_no_auth, api_db_session):
+        """Today's packets are excluded from the breakdown window."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+
+        api_db_session.add_all(
+            [
+                RawPacket(event_type="advert", received_at=now),
+                RawPacket(event_type="advert", received_at=yesterday),
+            ]
+        )
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        event_total = sum(b["count"] for b in data["by_event_type"])
+        assert event_total == 1  # only yesterday's packet
+
+    def test_event_type_top_six_plus_other(self, client_no_auth, api_db_session):
+        """Top 6 event types are shown verbatim; remainder rolls into 'other'."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+        # 8 distinct event types with descending counts.
+        types = [
+            ("type_a", 10),
+            ("type_b", 9),
+            ("type_c", 8),
+            ("type_d", 7),
+            ("type_e", 6),
+            ("type_f", 5),
+            ("type_g", 3),
+            ("type_h", 2),
+        ]
+        for event_type, n in types:
+            for _ in range(n):
+                api_db_session.add(
+                    RawPacket(event_type=event_type, received_at=yesterday)
+                )
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        buckets = data["by_event_type"]
+        assert len(buckets) == 7  # 6 verbatim + "other"
+        assert [b["label"] for b in buckets[:6]] == [
+            "type_a",
+            "type_b",
+            "type_c",
+            "type_d",
+            "type_e",
+            "type_f",
+        ]
+        assert buckets[6]["label"] == "other"
+        assert buckets[6]["count"] == 5  # type_g + type_h
+
+    def test_event_type_no_other_when_le_six(self, client_no_auth, api_db_session):
+        """No 'other' bucket is emitted when distinct types <= 6."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+        for event_type, n in [("type_a", 3), ("type_b", 2), ("type_c", 1)]:
+            for _ in range(n):
+                api_db_session.add(
+                    RawPacket(event_type=event_type, received_at=yesterday)
+                )
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        labels = [b["label"] for b in data["by_event_type"]]
+        assert "other" not in labels
+        assert len(labels) == 3
+
+    def test_path_width_fixed_order_zero_fill(self, client_no_auth, api_db_session):
+        """Path-width buckets are always 1b/2b/3b, zero-filled, NULL excluded."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+        # Seed: two widths present, one missing, plus a NULL.
+        for _ in range(4):
+            api_db_session.add(RawPacket(path_hash_bytes=1, received_at=yesterday))
+        for _ in range(2):
+            api_db_session.add(RawPacket(path_hash_bytes=3, received_at=yesterday))
+        api_db_session.add(RawPacket(path_hash_bytes=None, received_at=yesterday))
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        widths = data["by_path_width"]
+        assert [w["label"] for w in widths] == ["1b", "2b", "3b"]
+        assert widths[0]["count"] == 4
+        assert widths[1]["count"] == 0  # zero-filled
+        assert widths[2]["count"] == 2
+        # NULL excluded from denominator.
+        width_total = sum(w["count"] for w in widths)
+        assert width_total == 6
+
+    def test_path_width_excludes_null(self, client_no_auth, api_db_session):
+        """Rows with NULL path_hash_bytes are excluded from all width buckets."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+        api_db_session.add_all(
+            [
+                RawPacket(path_hash_bytes=2, received_at=yesterday),
+                RawPacket(path_hash_bytes=None, received_at=yesterday),
+                RawPacket(path_hash_bytes=None, received_at=yesterday),
+            ]
+        )
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        widths = data["by_path_width"]
+        assert widths[0]["count"] == 0  # 1b
+        assert widths[1]["count"] == 1  # 2b
+        assert widths[2]["count"] == 0  # 3b
+
+    def test_breakdown_response_shape(self, client_no_auth, api_db_session):
+        """Response conforms to PacketBreakdown schema."""
+        now = datetime.now(timezone.utc)
+        yesterday = now - timedelta(days=1)
+        api_db_session.add(
+            RawPacket(event_type="advert", path_hash_bytes=1, received_at=yesterday)
+        )
+        api_db_session.commit()
+
+        data = client_no_auth.get("/api/v1/dashboard/packet-breakdown?days=7").json()
+        assert "days" in data
+        assert "by_event_type" in data
+        assert "by_path_width" in data
+        assert isinstance(data["by_event_type"], list)
+        assert isinstance(data["by_path_width"], list)
+        for bucket in data["by_event_type"] + data["by_path_width"]:
+            assert "label" in bucket
+            assert "count" in bucket
+            assert isinstance(bucket["count"], int)
+
+
 class TestMessageActivity:
     """Tests for GET /dashboard/message-activity endpoint."""
 


### PR DESCRIPTION
## Summary

Add two horizontal 100% stacked-bar charts to the Dashboard, gated behind the existing `packets` feature flag:

- **Packet Types** — top 6 `event_type` values by count, remainder rolled into "other"
- **Path Bytes** — `1b`/`2b`/`3b` path-hash width distribution (NULL excluded)

Both charts share a single new cached endpoint `GET /api/v1/dashboard/packet-breakdown?days=7` that returns pre-bucketed counts. The frontend normalizes to percentages via a new `createStackedBarChart` helper in `charts.js` with a 7-hue hardcoded oklch palette.

## Changes

| Area | Files |
|------|-------|
| Backend | `dashboard.py` (new endpoint), `messages.py` (`BreakdownBucket`/`PacketBreakdown` schemas) |
| Frontend | `charts.js` (palette + `createStackedBarChart` + extended `initDashboardCharts`), `dashboard.js` (2-card grid row, fetch wiring, chart cleanup) |
| i18n | `en.json` / `nl.json` (3 new keys each) |
| Tests | `test_dashboard.py` — 9 new tests in `TestPacketBreakdown` |

## Test plan

- [x] `pytest --no-cov tests/test_api/test_dashboard.py` — 59 passed
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Full suite: 1195 passed, 22 skipped
- [ ] `make build && make up` — Docker build + SPA bundle
- [ ] Visual check (`FEATURE_PACKETS=true`): new 2-col row, proportional segments, tooltips show count + %, headlines show totals
- [ ] Visual check (`FEATURE_PACKETS=false`): cards absent, no breakdown fetch

Closes the plan at `docs/plans/20260704-1429-packet-breakdown-charts/`.