### PR TITLE
chore(routes): default window_hours=48 and max_hop_span=8

### DIFF
--- a/src/meshcore_hub/collector/cli.py
+++ b/src/meshcore_hub/collector/cli.py
@@ -804,12 +804,12 @@ def _import_routes(
                     route.description = value.get("description")
                     route.visibility = visibility
                     route.match_width = match_width
-                    route.window_hours = value.get("window_hours", 24)
+                    route.window_hours = value.get("window_hours", 48)
                     route.packet_count_threshold = value.get(
                         "packet_count_threshold", 3
                     )
                     route.clear_threshold = value.get("clear_threshold")
-                    route.max_hop_span = value.get("max_hop_span")
+                    route.max_hop_span = value.get("max_hop_span", 8)
                     route.enabled = value.get("enabled", True)
                     route.reversible = value.get("reversible", True)
                     # Replace path nodes wholesale
@@ -826,10 +826,10 @@ def _import_routes(
                         description=value.get("description"),
                         visibility=visibility,
                         match_width=match_width,
-                        window_hours=value.get("window_hours", 24),
+                        window_hours=value.get("window_hours", 48),
                         packet_count_threshold=value.get("packet_count_threshold", 3),
                         clear_threshold=value.get("clear_threshold"),
-                        max_hop_span=value.get("max_hop_span"),
+                        max_hop_span=value.get("max_hop_span", 8),
                         enabled=value.get("enabled", True),
                         reversible=value.get("reversible", True),
                     )

--- a/src/meshcore_hub/common/models/route.py
+++ b/src/meshcore_hub/common/models/route.py
@@ -69,7 +69,7 @@ class Route(Base, UUIDMixin, TimestampMixin):
     )
     window_hours: Mapped[int] = mapped_column(
         Integer,
-        default=24,
+        default=48,
         nullable=False,
     )
     packet_count_threshold: Mapped[int] = mapped_column(
@@ -83,6 +83,7 @@ class Route(Base, UUIDMixin, TimestampMixin):
     )
     max_hop_span: Mapped[Optional[int]] = mapped_column(
         Integer,
+        default=8,
         nullable=True,
     )
     enabled: Mapped[bool] = mapped_column(

--- a/src/meshcore_hub/common/schemas/routes.py
+++ b/src/meshcore_hub/common/schemas/routes.py
@@ -64,7 +64,7 @@ class RouteCreate(BaseModel):
         default=1, ge=1, le=3, description="Hash prefix width (1-3 bytes)"
     )
     window_hours: int = Field(
-        default=24, ge=1, le=720, description="Evaluation window in hours"
+        default=48, ge=1, le=720, description="Evaluation window in hours"
     )
     packet_count_threshold: int = Field(
         default=3, ge=1, le=10000, description="Minimum distinct packets for healthy"
@@ -73,7 +73,7 @@ class RouteCreate(BaseModel):
         default=None, description="Comfort bar (null = 2x threshold)"
     )
     max_hop_span: Optional[int] = Field(
-        default=None, description="Max hop distance between first and last node"
+        default=8, description="Max hop distance between first and last node"
     )
     enabled: bool = Field(default=True, description="Whether this route is evaluated")
     reversible: bool = Field(
@@ -232,10 +232,10 @@ class RoutePreviewRequest(BaseModel):
         ..., description="Ordered path node public keys"
     )
     match_width: int = Field(default=1, ge=1, le=3)
-    window_hours: int = Field(default=24, ge=1, le=720)
+    window_hours: int = Field(default=48, ge=1, le=720)
     packet_count_threshold: int = Field(default=3, ge=1, le=10000)
     clear_threshold: Optional[int] = None
-    max_hop_span: Optional[int] = None
+    max_hop_span: Optional[int] = Field(default=8)
     observer_public_keys: Optional[list[str]] = None
     reversible: bool = Field(default=True)
 

--- a/src/meshcore_hub/web/static/js/spa/pages/routes.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/routes.js
@@ -400,7 +400,7 @@ function renderRouteModal({ modalState, onSave, onCancel, saving }) {
                         <div>
                             <label class="text-sm opacity-70">${t('routes.window_label')}</label>
                             <input type="number" id="route-modal-window" class="input input-sm w-full"
-                                .value=${route.window_hours || 24} min="1" max="720" />
+                                .value=${route.window_hours || 48} min="1" max="720" />
                         </div>
                         <div>
                             <label class="text-sm opacity-70">${t('routes.threshold_label')}</label>
@@ -633,7 +633,7 @@ export async function render(container, params, router) {
         }
 
         function handleAdd() {
-            modalState = _newModalState('add', { visibility: 'community', enabled: true, match_width: 1 });
+            modalState = _newModalState('add', { visibility: 'community', enabled: true, match_width: 1, window_hours: 48, max_hop_span: 8 });
             renderPage(routes);
         }
 
@@ -803,7 +803,7 @@ export async function render(container, params, router) {
                 description: descEl.value.trim() || null,
                 visibility: visEl.value,
                 match_width: parseInt(widthEl.value, 10) || 1,
-                window_hours: parseInt(windowEl.value, 10) || 24,
+                window_hours: parseInt(windowEl.value, 10) || 48,
                 packet_count_threshold: parseInt(thresholdEl.value, 10) || 3,
                 max_hop_span: spanEl.value ? parseInt(spanEl.value, 10) : null,
                 enabled: enabledEl.checked,


### PR DESCRIPTION
## What

Updates the **new-route defaults** so the create modal, REST API, and YAML import all pre-fill:

| Field | Old default | New default |
|---|---|---|
| Window (hours) | 24 | **48** |
| Max Span (path length) | ∅ (∞) | **8** |

## Why

The previous 24h / unlimited defaults were too narrow on window and too permissive on hop span for typical multi-hop route evaluation. 48h / 8 covers realistic community deployments out of the box without forcing every user to override.

## Changes

- `schemas/routes.py` — `RouteCreate` + `RoutePreviewRequest` Pydantic defaults (`window_hours` 24→48, `max_hop_span` None→8)
- `models/route.py` — `Route` SQLAlchemy INSERT-time defaults
- `collector/cli.py` — YAML import fallbacks for `routes:` entries that omit the fields
- `web/static/js/spa/pages/routes.js` — new-route modal pre-fills 48 / 8; fallback constants updated. Clearing the max-span field still sends `null` (no cap) — explicit empty still wins.

## Compatibility

- **No Alembic migration.** Both columns use Python-side `default=` (no `server_default`), so the DB schema is unchanged and SQLAlchemy only applies the new values at INSERT time.
- **Existing routes are untouched.** Rows already stored with `window_hours=24` or `max_hop_span=NULL` keep their values; this is a pure default change for new routes.
- Clearing the Max Span field in the UI still produces `null` (unlimited) — the new default only applies when the field isn\'t explicitly cleared.

## Tests

- `pytest --no-cov tests/test_api/test_routes.py tests/test_common/test_schemas_routes.py tests/test_collector/test_cli.py tests/test_collector/test_routes.py` → **166 passed**
- `pre-commit run --all-files` → clean (black, flake8, mypy, hooks)

No test asserted the old implicit defaults (every existing test passes these fields explicitly), so no test updates were required.