### PR TITLE
feat(dashboard): limit Route Health widget to community routes

### DIFF
--- a/src/meshcore_hub/api/routes/dashboard.py
+++ b/src/meshcore_hub/api/routes/dashboard.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql.elements import ColumnElement
 from meshcore_hub.api.auth import RequireRead
 from meshcore_hub.api.cache import cached, sorted_query_string
 from meshcore_hub.api.channel_visibility import (
-    VISIBILITY_LEVELS,
     get_max_visibility_level,
     get_visible_channel_indices,
     resolve_user_role,
@@ -28,6 +27,7 @@ from meshcore_hub.common.models import (
     NodeTag,
     RawPacket,
     Route,
+    RouteVisibility,
     UserProfile,
 )
 from meshcore_hub.common.models.route_result_history import RouteResultHistory
@@ -76,15 +76,13 @@ def _dashboard_recent_activity_key_builder(request: Request) -> str:
 
 
 def _dashboard_routes_overview_key_builder(request: Request) -> str:
-    """Role-scoped key for ``GET /dashboard/routes-overview``.
+    """Role-agnostic key for ``GET /dashboard/routes-overview``.
 
-    The endpoint filters admin/operator-only routes by visibility, so the
-    cache key must vary by role — otherwise an anonymous GET could fill the
-    cache with a response that hides admin routes, and a subsequent admin
-    GET would receive that same redacted response.
+    The endpoint surfaces only ``community``-visibility routes regardless
+    of the caller's role, so the response is identical for anonymous,
+    member, operator, and admin callers — no role dimension in the key.
     """
-    role = resolve_user_role(request) or "anonymous"
-    return f"dashboard/routes-overview:role={role}:{sorted_query_string(request)}"
+    return f"dashboard/routes-overview:{sorted_query_string(request)}"
 
 
 def _flood_only_filter(
@@ -729,9 +727,12 @@ def get_routes_overview(
       ``days``-long history (includes today) for the trend chart and
       per-route strip grid.
 
-    Role-visibility filtered the same way as ``GET /routes`` so members
-    don't see admin-only routes. ``days`` is clamped to the configured
-    raw-packet retention window so history queries can't scan purged data.
+    The dashboard widget only surfaces ``community``-visibility routes,
+    regardless of the caller's role — operators and admins still see
+    member/operator/admin-tier routes on the dedicated ``/routes`` page,
+    but the dashboard is intentionally limited to the community fleet.
+    ``days`` is clamped to the configured raw-packet retention window so
+    history queries can't scan purged data.
 
     History is read in a single bulk query against ``route_result_history``
     for every visible route — no per-route scans of ``packet_path_hops``
@@ -742,11 +743,16 @@ def get_routes_overview(
     retention = get_collector_settings().effective_raw_packet_retention_days
     days = min(days, retention)
 
-    role = resolve_user_role(request)
-    max_level = get_max_visibility_level(role)
-
-    routes = session.execute(select(Route).order_by(Route.from_label)).scalars().all()
-    visible = [r for r in routes if VISIBILITY_LEVELS.get(r.visibility, 0) <= max_level]
+    routes = (
+        session.execute(
+            select(Route)
+            .where(Route.visibility == RouteVisibility.COMMUNITY.value)
+            .order_by(Route.from_label)
+        )
+        .scalars()
+        .all()
+    )
+    visible = list(routes)
 
     # Bulk-load precomputed history for every visible route in one indexed
     # query. ``read_route_history_from_db`` pads missing days and appends

--- a/tests/test_api/test_dashboard.py
+++ b/tests/test_api/test_dashboard.py
@@ -1499,8 +1499,13 @@ class TestRoutesOverview:
             "no_coverage",
         }
 
-    def test_visibility_filter_hides_admin_routes(self, client_no_auth, api_db_session):
-        """Anonymous users must not see admin-only routes in the overview."""
+    def test_dashboard_only_shows_community_routes_regardless_of_role(
+        self, client_no_auth, api_db_session
+    ):
+        """The dashboard widget surfaces only ``community``-visibility routes,
+        regardless of the caller's role — admins still see member/operator/
+        admin-tier routes on the dedicated ``/routes`` page, but the dashboard
+        is intentionally limited to the community fleet."""
         _make_route_with_nodes(
             api_db_session,
             "Public",
@@ -1510,25 +1515,36 @@ class TestRoutesOverview:
         )
         _make_route_with_nodes(
             api_db_session,
-            "Secret",
+            "MembersOnly",
             "Endpoint",
             ["c" * 64, "d" * 64],
+            visibility="member",
+        )
+        _make_route_with_nodes(
+            api_db_session,
+            "OperatorsOnly",
+            "Endpoint",
+            ["e" * 64, "f" * 64],
+            visibility="operator",
+        )
+        _make_route_with_nodes(
+            api_db_session,
+            "AdminOnly",
+            "Endpoint",
+            ["g" * 64, "h" * 64],
             visibility="admin",
         )
         api_db_session.commit()
 
-        # Anonymous: only the community route.
-        anon = client_no_auth.get("/api/v1/dashboard/routes-overview").json()
-        labels = [r["from_label"] for r in anon["routes"]]
-        assert labels == ["Public"]
-
-        # Admin sees both.
-        admin = client_no_auth.get(
-            "/api/v1/dashboard/routes-overview",
-            headers={"X-User-Roles": "admin"},
-        ).json()
-        admin_labels = sorted(r["from_label"] for r in admin["routes"])
-        assert admin_labels == ["Public", "Secret"]
+        for role_header in (None, "member", "operator", "admin"):
+            headers = {"X-User-Roles": role_header} if role_header else {}
+            resp = client_no_auth.get(
+                "/api/v1/dashboard/routes-overview", headers=headers
+            )
+            labels = [r["from_label"] for r in resp.json()["routes"]]
+            assert labels == [
+                "Public"
+            ], f"role={role_header!r} saw {labels!r}; expected ['Public'] only"
 
     def test_by_state_buckets_current_state(self, client_no_auth, api_db_session):
         """``by_state`` counts route current state across the fleet."""
@@ -1604,9 +1620,10 @@ class TestRoutesOverview:
         assert route["state"] == "disabled"
         assert route["matched_count"] is None
 
-    def test_cache_key_is_role_scoped(self, client_no_auth, api_db_session):
-        """Different roles get independent cache entries (sanity: both
-        return 200, response differs when visibility-filtered)."""
+    def test_cache_key_is_role_agnostic(self, client_no_auth, api_db_session):
+        """The dashboard widget returns the same payload for every role, so the
+        cache key must not vary by role — one cache fill is reused across
+        anonymous / member / operator / admin callers."""
         from unittest.mock import MagicMock
 
         _make_route_with_nodes(
@@ -1615,6 +1632,13 @@ class TestRoutesOverview:
             "End",
             ["a" * 64, "b" * 64],
             visibility="admin",
+        )
+        _make_route_with_nodes(
+            api_db_session,
+            "Public",
+            "End",
+            ["c" * 64, "d" * 64],
+            visibility="community",
         )
         api_db_session.commit()
 
@@ -1633,13 +1657,26 @@ class TestRoutesOverview:
         client_no_auth.get("/api/v1/dashboard/routes-overview")
         client_no_auth.get(
             "/api/v1/dashboard/routes-overview",
+            headers={"X-User-Roles": "member"},
+        )
+        client_no_auth.get(
+            "/api/v1/dashboard/routes-overview",
+            headers={"X-User-Roles": "operator"},
+        )
+        client_no_auth.get(
+            "/api/v1/dashboard/routes-overview",
             headers={"X-User-Roles": "admin"},
         )
 
-        # Two cache fills, role differs between them.
-        assert len(keys_seen) == 2
-        assert any("anonymous" in k for k in keys_seen)
-        assert any("admin" in k for k in keys_seen)
+        # Every caller produces the SAME key — no role dimension. The mock
+        # cache always misses (``get`` returns None), so all four requests
+        # re-fill; the point is that they all fill the SAME slot.
+        assert len(keys_seen) == 4
+        assert len(set(keys_seen)) == 1
+        key = keys_seen[0]
+        assert "role=" not in key
+        assert "anonymous" not in key
+        assert "admin" not in key
 
     def test_history_served_from_precomputed_table(
         self, client_no_auth, api_db_session


### PR DESCRIPTION
## What

The **Route Health** widget (and the sibling **Routes Trend** card, which shares the same payload) now surfaces only `community`-visibility routes, regardless of the logged-in user's role. Previously, the widget filtered by the caller's role tier — anonymous saw `community`, but members/operators/admins saw their progressively wider tier set, including admin-only routes mixed into the dashboard.

## Why

The dashboard is the at-a-glance network overview. Operators and admins already have the dedicated `/routes` page for working with member/operator/admin-tier routes (grouped by tier, with full edit/delete controls) — surfacing those same private-tier routes on the dashboard mixes audience and creates noise. Limiting the dashboard to `community` routes gives every viewer the same, stable, public-fleet health view, while the management surface stays unchanged for the people who need it.

## Changes

**`src/meshcore_hub/api/routes/dashboard.py`** (2 edits)

1. `get_routes_overview` (lines 712–815): drop the `resolve_user_role` / `get_max_visibility_level` computation and the Python-side `[r for r in routes if VISIBILITY_LEVELS.get(...) <= max_level]` filter. Replace with a SQL-level filter pushed into the query:
   ```python
   select(Route).where(Route.visibility == RouteVisibility.COMMUNITY.value).order_by(Route.from_label)
   ```
   So higher-tier rows are no longer loaded just to be discarded.

2. `_dashboard_routes_overview_key_builder` (lines 78–85): drop the `role=` dimension from the cache key. The response is now identical across all roles, so the per-role slots were storing four identical copies. Key becomes:
   ```
   dashboard/routes-overview:<query>
   ```
   The `dashboard/routes-overview:` prefix is preserved so `invalidate_routes`'s pattern-based drop (`api/cache_invalidation.py:99`) keeps working unchanged.

3. Imports: drop now-unused `VISIBILITY_LEVELS`; add `RouteVisibility` to the `meshcore_hub.common.models` import block.

**`tests/test_api/test_dashboard.py`** (2 tests rewritten)

- `test_visibility_filter_hides_admin_routes` → `test_dashboard_only_shows_community_routes_regardless_of_role`: seeds one route per visibility tier (`community`/`member`/`operator`/`admin`) and asserts **every** role variant (anonymous / member / operator / admin) sees only `['Public']`.
- `test_cache_key_is_role_scoped` → `test_cache_key_is_role_agnostic`: mocks the cache backend and asserts all four role variants produce the **same** cache key, with no `role=` substring.

## Scope (explicitly unchanged)

- `GET /api/v1/routes` (the `/routes` management page list endpoint) — keeps role-tiered visibility.
- `GET /routes/{id}` and `GET /routes/{id}/history` — keep role-tiered visibility.
- Route mutation endpoints (`POST`/`PUT`/`DELETE`) — unchanged (`RequireAdmin`).
- The `Route.visibility` model field and its 4-tier taxonomy — unchanged.
- No Alembic migration — pure Python/SQL change.

## Compatibility

- **No schema migration.** No DB column changes; the `visibility` column and its data are unchanged.
- **Behaviour change is intentional and called out:** admins/operators who previously relied on the dashboard showing their private-tier routes will no longer see them there. Those routes remain fully visible and manageable on `/routes`. This is the user-requested behaviour.
- **Cache:** existing role-keyed slots (`dashboard/routes-overview:role=*`) will be orphaned on deploy until they expire at `REDIS_CACHE_TTL_DASHBOARD` (default 3600 s). They take no memory of consequence and disappear on their own; no manual flush needed. Subsequent writes use the new role-agnostic key.

## Tests

```
pytest --no-cov tests/test_api/test_dashboard.py tests/test_api/test_cache.py
# → 192 passed

pytest --no-cov   # full suite
# → 1460 passed, 22 skipped
```

`pre-commit run --all-files` → clean (black, flake8, mypy, hooks).

## Docs

No doc edits required. `docs/routes.md:44` describes the `/routes` management page visibility rules, which are unchanged. The dashboard endpoint has never been separately documented; this PR doesn't introduce that gap.