### PR TITLE
fix(routes): clearing observers in the edit modal now persists

### DIFF
--- a/src/meshcore_hub/web/static/js/spa/pages/routes.js
+++ b/src/meshcore_hub/web/static/js/spa/pages/routes.js
@@ -809,7 +809,7 @@ export async function render(container, params, router) {
                 enabled: enabledEl.checked,
                 reversible: reversibleEl.checked,
                 node_public_keys: nodePublicKeys,
-                observer_public_keys: observerPublicKeys.length > 0 ? observerPublicKeys : null,
+                observer_public_keys: observerPublicKeys,
             };
 
             const clearVal = clearEl.value.trim();

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -995,6 +995,42 @@ class TestUpdateRouteFields:
         assert len(data["route_observers"]) == 1
         assert data["route_observers"][0]["public_key"] == obs.public_key
 
+    def test_update_clear_observers_with_empty_list(
+        self, client_no_auth, api_db_session
+    ):
+        """Sending ``observer_public_keys: []`` must clear existing observers.
+
+        Regression guard for a frontend bug where the edit modal sent
+        ``null`` instead of ``[]`` when the user removed all observers,
+        causing the backend's ``is not None`` guard to skip the sync.
+        """
+        route = self._make_route(api_db_session)
+        obs = _make_node(api_db_session, "c" * 64, "Observer")
+        api_db_session.commit()
+
+        # Seed one observer.
+        client_no_auth.put(
+            f"/api/v1/routes/{route.id}",
+            json={"observer_public_keys": [obs.public_key]},
+            headers={"X-User-Roles": "admin"},
+        )
+
+        # Clear with an explicit empty list.
+        resp = client_no_auth.put(
+            f"/api/v1/routes/{route.id}",
+            json={"observer_public_keys": []},
+            headers={"X-User-Roles": "admin"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["route_observers"] == []
+
+        # Confirm persistence via a fresh GET.
+        detail = client_no_auth.get(
+            f"/api/v1/routes/{route.id}",
+            headers={"X-User-Roles": "admin"},
+        ).json()
+        assert detail["route_observers"] == []
+
     def test_update_unresolved_path_nodes_400(self, client_no_auth, api_db_session):
         route = self._make_route(api_db_session)
         api_db_session.commit()


### PR DESCRIPTION
## What

Fixes a bug where removing all observers in the Route edit modal silently failed — the PUT returned 200, but the observers came back on next page load.

## Root cause

`src/meshcore_hub/web/static/js/spa/pages/routes.js:812` built the PUT body with a ternary that collapsed an empty observer list to `null`:

```javascript
observer_public_keys: observerPublicKeys.length > 0 ? observerPublicKeys : null,
```

On the backend, Pydantic parsed `null` as `None`, and the PUT handler's guard at `api/routes/routes.py:589` skipped the sync:

```python
if body.observer_public_keys is not None:
    observer_nodes = _resolve_nodes_by_pubkey(session, body.observer_public_keys)
    _sync_observers(session, route, observer_nodes)
```

So:
- **Add observers** → array → guard passes → `_sync_observers` deletes + recreates → worked.
- **Clear observers** → `null` → guard failed → `_sync_observers` skipped → DB unchanged.

The `None`-means-skip semantic is correct for partial PATCH-style updates, so the bug is purely on the frontend: the route modal is a **full-form PUT** (every field is sent every time), so it shouldn't use the "send null when empty" pattern.

## Fix

One-line change in `routes.js` — always send the array:

```javascript
// Before
observer_public_keys: observerPublicKeys.length > 0 ? observerPublicKeys : null,
// After
observer_public_keys: observerPublicKeys,
```

When empty, JS serializes `[]`, Pydantic parses as `[]` (not `None`), the guard passes, and `_sync_observers` deletes every existing `RouteObserver` row.

## Regression test

`tests/test_api/test_routes.py` — added `test_update_clear_observers_with_empty_list` next to the existing `test_update_observers`. It:
1. PUTs with one observer pubkey → asserts the response has 1 observer.
2. PUTs again with `observer_public_keys: []` → asserts response `route_observers` is `[]`.
3. GETs the detail endpoint to confirm persistence (catches any future "response lies but DB didn't update" regression).

This locks the contract so a future client (frontend or otherwise) can't silently reintroduce the bug by sending `null` for the empty case.

## Scope (explicitly unchanged)

- `RouteUpdate.observer_public_keys: Optional[list[str]] = None` — the `None`-means-skip semantic stays; it's correct for true partial updates from other clients.
- `_sync_observers` (`routes.py:158`) — already does delete-all-then-recreate correctly.
- Create flow — `null` and `[]` are equivalent on create (both mean "all observers"), so the same line worked by accident when creating. No change needed.
- `node_public_keys` (line 811) — already sends the array unconditionally; no change.
- Preview endpoint — read-only.

## Tests

```
pytest --no-cov tests/test_api/test_routes.py
# → 50 passed

pytest --no-cov   # full suite
# → 1461 passed, 22 skipped
```

`pre-commit run --all-files` → clean (black, flake8, mypy, hooks).

## Manual verification

Build the stack, then in the running app:

1. Open `/routes`, edit a route, add an observer, save. Confirm it appears.
2. Re-edit the same route, click ✕ on the observer chip (so the chip list is empty), save.
3. Reload the page. Observer list is now empty.