### PR TITLE
fix: Channels page crash from query cache shape collision

### DIFF
--- a/src/meshcore_hub/web/static/js/spa-react/pages/Channels.test.tsx
+++ b/src/meshcore_hub/web/static/js/spa-react/pages/Channels.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { Channels } from "@/pages/Channels";
-import { renderWithProviders } from "@/test/renderWithProviders";
+import { renderWithProviders, createTestQueryClient } from "@/test/renderWithProviders";
 import { makeConfig } from "@/test/makeConfig";
 import * as api from "@/utils/api";
 
@@ -67,6 +67,17 @@ describe("Channels", () => {
     renderWithProviders(<Channels />);
     await waitFor(() => {
       expect(screen.queryByText("Public")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders correctly when cache was pre-populated by Dashboard (raw object shape)", async () => {
+    mockChannelsApi();
+    const client = createTestQueryClient();
+    client.setQueryData(["channels", "list", {}], CHANNELS);
+    renderWithProviders(<Channels />, { client });
+    await waitFor(() => {
+      expect(screen.getByText("Public")).toBeInTheDocument();
+      expect(screen.getByText("Ops")).toBeInTheDocument();
     });
   });
 });

--- a/src/meshcore_hub/web/static/js/spa-react/pages/Channels.tsx
+++ b/src/meshcore_hub/web/static/js/spa-react/pages/Channels.tsx
@@ -293,16 +293,10 @@ export function Channels() {
     error: queryError,
   } = useQuery({
     queryKey: qk.channels.list({}),
-    queryFn: async ({ signal }) => {
-      const resp = await apiGet<ChannelListResponse>(
-        "/api/v1/channels",
-        {},
-        { signal },
-      );
-      return resp.items || [];
-    },
+    queryFn: ({ signal }) =>
+      apiGet<ChannelListResponse>("/api/v1/channels", {}, { signal }),
   });
-  const channels = data ?? [];
+  const channels = data?.items ?? [];
   const error = queryError ? queryError.message : null;
   const [modal, setModal] = useState<ModalState | null>(null);
 


### PR DESCRIPTION
## Summary

The Channels page crashed with `TypeError: g is not iterable` when visited after the Dashboard page within React Query's 30s stale window.

**Root cause:** `Dashboard.tsx` and `Channels.tsx` both used the query key `qk.channels.list({})` but their `queryFn`s returned different data shapes:

- **Dashboard** returned the raw API response `{items: [...], total: N}` (object)
- **Channels** returned `resp.items || []` (array)

When Dashboard loaded first, React Query cached the raw object. Channels then received it as `data`, and `for (const ch of data)` threw because a plain object is not iterable.

## Fix

- **Channels.tsx**: queryFn now returns the raw `apiGet` response (matching Dashboard), and extraction changed to `data?.items ?? []`
- **Channels.test.tsx**: added regression test that pre-seeds the query cache with the Dashboard shape (`{items, total}`) before rendering Channels

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:frontend` — 59 files, 316 tests pass
- [ ] Manual: visit Dashboard, then Channels within 30s — no crash