### PR TITLE
Fix horizontal overflow on Dashboard and Routes (mobile portrait)

### DIFF
--- a/src/meshcore_hub/web/static/js/spa-react/pages/Dashboard.tsx
+++ b/src/meshcore_hub/web/static/js/spa-react/pages/Dashboard.tsx
@@ -563,7 +563,7 @@ export function DashboardPage() {
         <div className={`grid grid-cols-1 ${gridCols(bottomCount)} gap-6`}>
           {showAdverts && (
             <div
-              className="card bg-base-100 shadow-xl panel-accent"
+              className="card bg-base-100 shadow-xl panel-accent min-w-0"
               style={panelStyle("--color-adverts")}
             >
               <div className="card-body">
@@ -604,12 +604,12 @@ export function DashboardPage() {
                                   to={`/nodes/${ad.public_key}`}
                                   className="link link-hover"
                                 >
-                                  <div className="font-medium">
+                                  <div className="font-medium max-w-[10rem] truncate">
                                     {displayName}
                                   </div>
                                 </Link>
                                 {friendlyName && (
-                                  <div className="text-xs opacity-50 font-mono">
+                                  <div className="text-xs opacity-50 font-mono max-w-[10rem] truncate">
                                     {ad.public_key.slice(0, 12)}...
                                   </div>
                                 )}
@@ -642,7 +642,7 @@ export function DashboardPage() {
 
           {showMessages && channelEntries.length > 0 && (
             <div
-              className="card bg-base-100 shadow-xl panel-accent"
+              className="card bg-base-100 shadow-xl panel-accent min-w-0"
               style={panelStyle("--color-messages")}
             >
               <div className="card-body">

--- a/src/meshcore_hub/web/static/js/spa-react/pages/Routes.tsx
+++ b/src/meshcore_hub/web/static/js/spa-react/pages/Routes.tsx
@@ -466,12 +466,12 @@ function DetailContent({
   return (
     <div className="mt-2 space-y-3 text-sm">
       {history && (
-        <div className="mb-3">
+        <div className="mb-3 min-w-0">
           <RouteDetailStrip data={history} />
           {historyData.length > 0 && (
-            <div className="flex text-xs opacity-50 mt-0.5">
+            <div className="flex text-xs opacity-50 mt-0.5 min-w-0">
               {historyData.map((d, i) => (
-                <span key={d.date} className="flex-1 text-center">
+                <span key={d.date} className="flex-1 text-center min-w-0 truncate">
                   {i === historyData.length - 1
                     ? t("routes.last_n_hours", { n: route.window_hours })
                     : new Date(`${d.date}T00:00:00`).toLocaleDateString(
@@ -487,7 +487,7 @@ function DetailContent({
       {matches.length > 0 && (
         <div>
           <strong className="opacity-70">{t("routes.recent_packets")}</strong>
-          <div className="mt-2 space-y-2">
+          <div className="mt-2 space-y-2 overflow-hidden">
             {matches.map((m, i) => (
               <MatchRow
                 key={`${m.packet_hash || "match"}-${i}`}
@@ -542,7 +542,7 @@ function RouteCard({
 
   return (
     <div
-      className="card bg-base-100 shadow-xl h-full"
+      className="card bg-base-100 shadow-xl h-full min-w-0"
       data-testid="route-card"
       data-route-label={`${route.from_label} → ${route.to_label}`}
     >


### PR DESCRIPTION
## Summary

Fixes two horizontal overflow issues on mobile portrait view:

1. **Dashboard Recent Adverts widget** — the card showed a horizontal scrollbar and overflowed the viewport.
2. **Routes page** — the page could be scrolled right with no visible scrollbar.

Both root causes are the same CSS pattern: **grid/flex items default to `min-width: auto`**, so they grow to fit their content's intrinsic width instead of constraining overflow wrappers.

## Changes

### Dashboard (`Dashboard.tsx`)

- Added `min-w-0` to the Adverts card and Messages card (both are CSS grid items in the bottom grid). This lets the card shrink so the existing `overflow-x-auto` wrapper can engage and scroll.
- Constrained the Node name cell with `max-w-[10rem] truncate` to reduce the table's intrinsic min-content width.

### Routes (`Routes.tsx`)

Three triggers pushed content wider than the viewport with no overflow containment anywhere in the ancestor chain:

| Fix | Location | What |
|-----|----------|------|
| `min-w-0` on card | RouteCard outer div | Grid item (via `SectionGroup`) can now shrink to track width |
| `min-w-0` on chart wrapper | `DetailContent` chart div | Constrains the Chart.js responsive `<canvas>` |
| `min-w-0 truncate` on labels | History day-label spans | 7 flex-1 date cells shrink and clip instead of blowing out the card |
| `overflow-hidden` on MatchRow parent | `mt-2 space-y-2` div | Clips the `-mx-1` hover-bg overflow at the card edge |

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 337/337 passing
- `pre-commit run --all-files` — all green