### PR TITLE
Fix remaining Routes horizontal overflow (card content not clipped)

### DIFF
--- a/src/meshcore_hub/web/static/js/spa-react/pages/Routes.tsx
+++ b/src/meshcore_hub/web/static/js/spa-react/pages/Routes.tsx
@@ -546,7 +546,7 @@ function RouteCard({
       data-testid="route-card"
       data-route-label={`${route.from_label} → ${route.to_label}`}
     >
-      <div className="card-body">
+      <div className="card-body overflow-hidden">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <h2 className="card-title">
@@ -1500,7 +1500,7 @@ export function RoutesPage() {
   }
 
   return (
-    <div>
+    <div className="overflow-x-hidden">
       <PageHeader title={t("entities.routes")} icon={IconPath} />
 
       <SummaryStrip routes={routes} />


### PR DESCRIPTION
## Summary

Follow-up to #341. The previous fix added `min-w-0` to the route card grid item, which prevented the card from **growing** — but did not **clip** content that overflowed the card boundary. The Chart.js canvas and flex items inside `card-body` (with default `min-width: auto`) still overflowed the card edge, causing page-level horizontal scroll on mobile.

## Root Cause

`min-w-0` on a grid item allows it to shrink, but does not establish overflow clipping. Content inside the card that is wider than the card (Chart.js responsive canvas, flex/grid items with intrinsic min-content width) remains visible beyond the card boundary, and with no `overflow-hidden` ancestor, it enables page-level scroll.

## Fix

Two className additions in `Routes.tsx`:

1. **`overflow-hidden` on `card-body`** (`:549`) — Clips all content overflow within each route card. Per CSS spec, setting `overflow` to a non-`visible` value on a flex/grid item also resolves its automatic minimum size to 0, so `card-body` itself can shrink to the card's width. Combined with the existing `min-w-0` on the card div, the card is fully constrained.

2. **`overflow-x-hidden` on the page root** (`:1503`) — Safety net for any non-card overflow. The div has no height constraint, so the resulting `overflow-y: auto` computation does not produce a vertical scrollbar.

**Tooltips are safe:** The card's tooltips are `tooltip-top` (StatsRow — extends upward with ample room from title + PathChips above) and `tooltip-left` (quality badge — extends leftward into the card). Neither extends beyond `card-body`'s bounds.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — 337/337 passing
- `pre-commit run --all-files` — all green