### PR TITLE
fix(e2e): pin @playwright/test to 1.61.1 to match nixpkgs browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "tailwindcss": "^4"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "1.61.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
@@ -767,19 +767,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -4185,35 +4185,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck:e2e": "tsc -p e2e/tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "1.61.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Pinned to match nixpkgs playwright.browsers; see shell.nix",
+      "matchPackageNames": ["@playwright/test"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Pin `@playwright/test` to exact `1.61.1` to match the browser binaries provided by nixpkgs, and disable future Renovate updates for this package.

## Problem

Renovate PR #340 bumped `@playwright/test` from 1.61.1 to 1.62.0 (the caret `^1.61.1` allowed the minor bump). On this NixOS system, Playwright browser binaries are managed by **nixpkgs** (`playwright.browsers`), which provides Playwright 1.61.1 with browser revision **1228**. Playwright 1.62.0 expects revision **1234**, which doesn't exist in the Nix store path (`PLAYWRIGHT_BROWSERS_PATH`), causing:

```
Error: browserType.launch: Executable doesn't exist at
/nix/store/.../chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell
```

## Changes

- **`package.json`**: `"@playwright/test": "^1.61.1"` -> `"1.61.1"` (exact pin, no caret)
- **`package-lock.json`**: downgraded `@playwright/test`, `playwright`, `playwright-core` from 1.62.0 to 1.61.1
- **`renovate.json`**: added `packageRules` entry to disable updates for `@playwright/test`

## Verification

- `npx playwright test --list` — 41 tests collected, browser binary found
- `npx tsc --noEmit` — clean
- `npx tsc -p e2e/tsconfig.json --noEmit` — clean
- `pre-commit` — all green
