### PR TITLE
fix(security): close fail-open defaults, header spoofing, and add CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -369,6 +369,12 @@ METRICS_ENABLED=true
 # Default: 60
 METRICS_CACHE_TTL=60
 
+# Allow unauthenticated /metrics access when no API read key is configured.
+# Default: deny. To expose metrics either set API_READ_KEY (and scrape with
+# Basic auth user "metrics" + the read key as password) or set this to true.
+# Default: false
+# METRICS_PUBLIC=false
+
 # CORS origins for the API server (comma-separated)
 # Only needed when running the web dashboard on a different origin than the API
 # Example: http://localhost:8080,http://localhost:3000
@@ -472,6 +478,17 @@ WEB_PORT=8080
 # Shows extra diagnostic info (e.g., raw user IDs in the user menu)
 # Default: false
 # WEB_DEBUG=false
+
+# Emit security headers (X-Content-Type-Options, X-Frame-Options,
+# Referrer-Policy, Permissions-Policy) and a nonce-based
+# Content-Security-Policy on web responses
+# Default: true
+# WEB_SECURITY_HEADERS=true
+
+# Extra CSP directives appended to the default policy
+# (e.g. "img-src https://tiles.example.com" for custom map tiles)
+# Default: empty
+# WEB_CSP_EXTRA=
 
 # -------------------
 # OIDC Authentication

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Health check endpoints are also available:
 
 - **Health**: http://localhost:8000/health
 - **Ready**: http://localhost:8000/health/ready (includes database check)
-- **Metrics**: http://localhost:8000/metrics (Prometheus format — point your Prometheus scraper here)
+- **Metrics**: http://localhost:8000/metrics (Prometheus format — requires `API_READ_KEY` + Basic auth user `metrics`, or `METRICS_PUBLIC=true`, when no key is set)
 
 ### Authentication
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,6 +314,8 @@ services:
       - API_ADMIN_KEY=${API_ADMIN_KEY:-}
       - METRICS_ENABLED=${METRICS_ENABLED:-true}
       - METRICS_CACHE_TTL=${METRICS_CACHE_TTL:-60}
+      # Allow unauthenticated /metrics when no API_READ_KEY is set (default: deny)
+      - METRICS_PUBLIC=${METRICS_PUBLIC:-false}
       # Redis cache (optional — API works without Redis)
       - REDIS_ENABLED=${REDIS_ENABLED:-false}
       - REDIS_HOST=redis

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -58,6 +58,16 @@ The proxy uses a hardcoded per-endpoint, per-method mapping in `src/meshcore_hub
 
 The SPA receives the user's roles array in `window.__APP_CONFIG__.roles`. Client-side pages use the `hasRole(roleName)` helper, which returns `true` when OIDC is disabled (open access) or when the user has the specified role.
 
+### Trust Model for Identity Headers
+
+When the web proxy forwards a request to the API, it injects `X-User-Id`, `X-User-Name`, and `X-User-Roles` headers derived from the OIDC session, alongside the API bearer key. These headers are only honoured by the API when a valid API key accompanies them (`require_user_owner` / `optional_user_identity` in `api/auth.py`) — client-supplied identity headers are dropped by the proxy and, with API keys configured, a bare `X-User-Id` sent directly to the API port is rejected. Keep the API port unreachable from untrusted networks; the API key is the trust anchor for proxy-injected identity.
+
+Server-side aggregations (e.g. `/map/data`) resolve the viewer's session and apply the same endpoint access mapping as the proxy, so tightening `v1/user/profiles` in `ENDPOINT_ACCESS` also removes profile data from `/map/data` for viewers who would be denied.
+
+### Session Security
+
+Sessions are signed with `OIDC_SESSION_SECRET` using a `SameSite=Lax` cookie (`meshcore-session`). **The web service refuses to start when `OIDC_ENABLED=true` and no secret is set** — there is no insecure fallback. Generate one with `python -c "import secrets; print(secrets.token_urlsafe(48))"`. Set `OIDC_COOKIE_SECURE=true` in production so cookies are restricted to HTTPS.
+
 ## Login Flow
 
 1. User visits `/admin/` — no session exists — server redirects to `/auth/login?next=/admin/`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,8 @@ REST API server. For multi-worker scaling guidance (`API_WORKERS`), see [deploym
 | `API_ADMIN_KEY` | _(none)_ | Admin API key |
 | `METRICS_ENABLED` | `true` | Enable Prometheus metrics endpoint at `/metrics` |
 | `METRICS_CACHE_TTL` | `60` | Seconds to cache metrics output (reduces database load) |
-| `CORS_ORIGINS` | _(none)_ | Comma-separated list of allowed CORS origins (only needed when the web dashboard runs on a different origin) |
+| `METRICS_PUBLIC` | `false` | Allow unauthenticated `/metrics` when no `API_READ_KEY` is set. Default denies; scrape with Basic auth (user `metrics`, password = read key) or opt in explicitly |
+| `CORS_ORIGINS` | _(none)_ | Comma-separated list of allowed CORS origins (only needed when the web dashboard runs on a different origin). Unset defaults to all origins **without** credentials |
 
 ## Web Dashboard
 
@@ -213,6 +214,8 @@ Web server, dashboard presentation, network metadata, and custom content. For th
 | `WEB_PORT` | `8080` | Web server port |
 | `API_BASE_URL` | `http://localhost:8000` | API endpoint URL |
 | `API_KEY` | _(none)_ | API key for web dashboard queries (optional — set if `API_READ_KEY` is set on the API) |
+| `WEB_SECURITY_HEADERS` | `true` | Emit security headers (nosniff, frame denial, referrer/permissions policy) and a nonce-based Content-Security-Policy |
+| `WEB_CSP_EXTRA` | _(none)_ | Extra CSP directives appended to the default policy (e.g. `img-src https://tiles.example.com` for custom map tiles) |
 | `WEB_THEME` | `dark` | Default theme (`dark` or `light`); users can override via the navbar toggle |
 | `WEB_LOCALE` | `en` | Locale/language for the web dashboard (e.g. `en`, `nl`) |
 | `WEB_DATETIME_LOCALE` | `en-US` | Locale used for date formatting (e.g. `en-US` for MM/DD/YYYY, `en-GB` for DD/MM/YYYY) |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -2,6 +2,22 @@
 
 This guide covers upgrading from a previous MeshCore Hub release to the current version. Check the relevant version section below before upgrading.
 
+## Unreleased — Security hardening (fail-closed defaults)
+
+Four behaviour changes tighten default security. **Two are potentially breaking for existing deployments — read before upgrading.**
+
+**⚠️ Breaking: `OIDC_SESSION_SECRET` is now mandatory when `OIDC_ENABLED=true`.** Previously the web tier silently fell back to a hard-coded `insecure-dev-secret`, meaning session cookies were forgeable by anyone who knew it. The web service now refuses to start without a real secret. Generate one with `python -c "import secrets; print(secrets.token_urlsafe(48))"` and set `OIDC_SESSION_SECRET` in your environment / `.env`.
+
+**⚠️ Breaking: `/metrics` denies unauthenticated access by default.** Previously, when no `API_READ_KEY` was configured, the Prometheus endpoint was public (it exports node names, public keys, and role counts, and is often exposed via reverse proxy). Now: set `API_READ_KEY` and scrape with Basic auth (username `metrics`, password = the read key), or explicitly opt back in with `METRICS_PUBLIC=true`. Existing scrapers will start seeing 401s until reconfigured.
+
+**Proxy-injected identity headers are now key-validated.** `GET /api/v1/user/profile/me` and the owner branch of `GET /api/v1/user/profile/{id}` no longer trust a bare `X-User-Id` header: when API keys are configured, the header is only honoured alongside a valid bearer key (exactly how the web proxy already sends it). This closes an OIDC subject-identifier leak to anyone with direct API port access.
+
+**`/map/data` follows the endpoint access model.** The server-side map aggregation now resolves the viewer's OIDC session and applies the same per-endpoint access mapping as the API proxy. Deployments that restrict `v1/user/profiles` no longer leak profile data (names, callsigns, roles) through `/map/data`, and the response is served `Cache-Control: private` when OIDC is enabled since the payload can vary by viewer.
+
+**Security headers + CSP.** The web tier now emits `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, and a nonce-based `Content-Security-Policy`; the API emits `nosniff`. Custom map tile hosts or other CSP exceptions can be added via `WEB_CSP_EXTRA`; set `WEB_SECURITY_HEADERS=false` to disable (not recommended). **Note for reverse-proxy deployments:** if you strip response headers or inject inline scripts at the proxy, verify the CSP nonce still matches.
+
+**CORS credentials tightened.** An unset `CORS_ORIGINS` still allows all origins for compatibility with external API consumers, but no longer advertises `allow-credentials` (wildcard origins are never valid with credentials in browsers anyway). Explicit origin lists are unchanged.
+
 ## Unreleased — Route evaluator performance remediation
 
 The background route evaluator was triggering a multi-second `packet_path_hops` scan per route per sweep, flooding the slow-query log and blocking route saves on the same scan. This release reduces load across four orthogonal levers. **Two are destructive / behaviour-changing — read before upgrading.**

--- a/src/meshcore_hub/api/app.py
+++ b/src/meshcore_hub/api/app.py
@@ -83,6 +83,7 @@ def create_app(
     cors_origins: list[str] | None = None,
     metrics_enabled: bool = True,
     metrics_cache_ttl: int = 60,
+    metrics_public: bool = False,
     redis_enabled: bool = False,
     redis_host: str = "localhost",
     redis_port: int = 6379,
@@ -112,6 +113,7 @@ def create_app(
         cors_origins: Allowed CORS origins
         metrics_enabled: Enable Prometheus metrics endpoint at /metrics
         metrics_cache_ttl: Seconds to cache metrics output
+        metrics_public: Allow unauthenticated /metrics when no read key is set
         redis_enabled: Enable Redis API response caching
         redis_host: Redis server host
         redis_port: Redis server port
@@ -150,6 +152,7 @@ def create_app(
     app.state.mqtt_transport = mqtt_transport
     app.state.mqtt_ws_path = mqtt_ws_path
     app.state.metrics_cache_ttl = metrics_cache_ttl
+    app.state.metrics_public = metrics_public
     app.state.redis_enabled = redis_enabled
     app.state.redis_host = redis_host
     app.state.redis_port = redis_port
@@ -162,14 +165,24 @@ def create_app(
     app.state.spam_detection_enabled = spam_detection_enabled
     app.state.spam_score_threshold = spam_score_threshold
 
-    # Configure CORS
+    # Configure CORS. An unset CORS_ORIGINS keeps the wildcard default for
+    # compatibility with external API consumers, but wildcard origins are
+    # never valid with credentials (browsers reject credentialed requests
+    # under Access-Control-Allow-Origin: *), so allow_credentials is only
+    # enabled for explicitly configured origin lists.
+    allow_credentials = True
     if cors_origins is None:
         cors_origins = ["*"]
+        allow_credentials = False
+        logger.warning(
+            "CORS_ORIGINS not configured; allowing all origins WITHOUT "
+            "credentials. Set CORS_ORIGINS to restrict cross-origin access."
+        )
 
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,
-        allow_credentials=True,
+        allow_credentials=allow_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )
@@ -203,6 +216,9 @@ def create_app(
         away.
         """
         response = await call_next(request)
+
+        # Hardening: block MIME-type sniffing on all API responses.
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
 
         # X-Cache observability header (always emitted, even when the kill
         # switch is on, so monitoring can still see hit/miss ratios).
@@ -309,6 +325,7 @@ def create_app_from_env() -> FastAPI:
 
     metrics_enabled = _env_bool("METRICS_ENABLED", True)
     metrics_cache_ttl = int(os.environ.get("METRICS_CACHE_TTL", "60"))
+    metrics_public = settings.metrics_public
 
     # mqtt_transport is an enum on the settings object; create_app wants a str.
     mqtt_transport = getattr(settings.mqtt_transport, "value", settings.mqtt_transport)
@@ -328,6 +345,7 @@ def create_app_from_env() -> FastAPI:
         cors_origins=cors_origins,
         metrics_enabled=metrics_enabled,
         metrics_cache_ttl=metrics_cache_ttl,
+        metrics_public=metrics_public,
         redis_enabled=settings.redis_enabled,
         redis_host=settings.redis_host,
         redis_port=settings.redis_port,

--- a/src/meshcore_hub/api/auth.py
+++ b/src/meshcore_hub/api/auth.py
@@ -141,6 +141,45 @@ async def require_admin(
     )
 
 
+async def optional_user_identity(
+    request: Request,
+    token: Annotated[str | None, Depends(get_current_token)],
+) -> str | None:
+    """Optionally resolve a proxy-injected user identity via X-User-Id header.
+
+    Same trust model as :func:`require_user_owner` — when API keys are
+    configured, the bearer key must be valid for the header to be trusted.
+    Unlike ``require_user_owner``, a missing header is not an error: it
+    returns ``None`` so public endpoints can fall back to anonymous access.
+
+    Returns:
+        The user_id string from the X-User-Id header, or None.
+
+    Raises:
+        HTTPException: 401 if a key is required but missing/invalid.
+    """
+    read_key, admin_key = get_api_keys(request)
+
+    if read_key or admin_key:
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        key_valid = (read_key and hmac.compare_digest(token, read_key)) or (
+            admin_key and hmac.compare_digest(token, admin_key)
+        )
+        if not key_valid:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid API key",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+    return request.headers.get(X_USER_ID_HEADER) or None
+
+
 # Dependency types for use in routes
 RequireRead = Annotated[str | None, Depends(require_read)]
 RequireAdmin = Annotated[str, Depends(require_admin)]
@@ -253,3 +292,4 @@ RequireOperator = Annotated[tuple[str, list[str]], Depends(require_operator)]
 RequireOperatorOrAdmin = Annotated[
     tuple[str, list[str]], Depends(require_operator_or_admin)
 ]
+OptionalUserIdentity = Annotated[str | None, Depends(optional_user_identity)]

--- a/src/meshcore_hub/api/cli.py
+++ b/src/meshcore_hub/api/cli.py
@@ -123,6 +123,15 @@ import click
     help="Seconds to cache metrics output (reduces database load)",
 )
 @click.option(
+    "--metrics-public/--no-metrics-public",
+    default=False,
+    envvar="METRICS_PUBLIC",
+    help=(
+        "Allow unauthenticated /metrics access when no read key is "
+        "configured (default: deny)"
+    ),
+)
+@click.option(
     "--redis-enabled/--no-redis",
     default=False,
     envvar="REDIS_ENABLED",
@@ -227,6 +236,7 @@ def api(
     cors_origins: str | None,
     metrics_enabled: bool,
     metrics_cache_ttl: int,
+    metrics_public: bool,
     redis_enabled: bool,
     redis_host: str,
     redis_port: int,
@@ -288,6 +298,7 @@ def api(
     click.echo(f"CORS origins: {cors_origins or 'none'}")
     click.echo(f"Metrics enabled: {metrics_enabled}")
     click.echo(f"Metrics cache TTL: {metrics_cache_ttl}s")
+    click.echo(f"Metrics public (no key): {metrics_public}")
     click.echo(f"Redis enabled: {redis_enabled}")
     if redis_enabled:
         click.echo(f"Redis: {redis_host}:{redis_port}/{redis_db}")
@@ -350,6 +361,7 @@ def api(
             cors_origins=origins_list,
             metrics_enabled=metrics_enabled,
             metrics_cache_ttl=metrics_cache_ttl,
+            metrics_public=metrics_public,
             redis_enabled=redis_enabled,
             redis_host=redis_host,
             redis_port=redis_port,

--- a/src/meshcore_hub/api/metrics.py
+++ b/src/meshcore_hub/api/metrics.py
@@ -35,8 +35,10 @@ _cache: dict[str, Any] = {"output": b"", "expires_at": 0.0}
 def verify_basic_auth(request: Request) -> bool:
     """Verify HTTP Basic Auth credentials for metrics endpoint.
 
-    Uses username 'metrics' and the API read key as password.
-    Returns True if no read key is configured (public access).
+    Uses username 'metrics' and the API read key as password. When a read
+    key is configured, valid Basic auth is always required. When no key is
+    configured, access is denied unless METRICS_PUBLIC (app.state
+    'metrics_public') explicitly opts in.
 
     Args:
         request: FastAPI request
@@ -46,9 +48,9 @@ def verify_basic_auth(request: Request) -> bool:
     """
     read_key = getattr(request.app.state, "read_key", None)
 
-    # No read key configured = public access
+    # No read key configured: deny unless explicitly made public
     if not read_key:
-        return True
+        return bool(getattr(request.app.state, "metrics_public", False))
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Basic "):
@@ -379,11 +381,18 @@ async def metrics(request: Request) -> Response:
     """Prometheus metrics endpoint.
 
     Returns metrics in Prometheus text exposition format.
-    Supports HTTP Basic Auth with username 'metrics' and API read key as password.
+    Supports HTTP Basic Auth with username 'metrics' and API read key as
+    password. When no read key is configured, access is denied unless
+    METRICS_PUBLIC=true explicitly opts in to unauthenticated access.
     Results are cached with a configurable TTL to reduce database load.
     """
     # Check authentication
     if not verify_basic_auth(request):
+        logger.warning(
+            "Denied unauthenticated /metrics request. To expose metrics: "
+            "set API_READ_KEY (scrape with Basic auth user 'metrics') or "
+            "set METRICS_PUBLIC=true."
+        )
         return PlainTextResponse(
             "Unauthorized",
             status_code=401,

--- a/src/meshcore_hub/api/routes/user_profiles.py
+++ b/src/meshcore_hub/api/routes/user_profiles.py
@@ -8,9 +8,9 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 
 from meshcore_hub.api.auth import (
+    OptionalUserIdentity,
     RequireRead,
     RequireUserOwner,
-    X_USER_ID_HEADER,
     X_USER_ROLES_HEADER,
 )
 from meshcore_hub.api.cache import cached
@@ -127,22 +127,18 @@ def list_profiles(
 
 @router.get("/profile/me", response_model=UserProfileWithNodes)
 def get_my_profile(
+    caller_id: RequireUserOwner,
     request: Request,
     session: DbSession,
 ) -> UserProfileWithNodes:
-    """Get the current user's profile (via X-User-Id header).
+    """Get the current user's profile (via validated X-User-Id header).
 
-    Auto-creates the profile if it doesn't exist. Returns the full
-    profile including user_id and adopted nodes.
+    The caller identity comes from the proxy-injected X-User-Id header,
+    which is only trusted when accompanied by a valid API key (see
+    ``require_user_owner``). Auto-creates the profile if it doesn't exist.
+    Returns the full profile including user_id and adopted nodes.
     """
-    oidc_user_id = request.headers.get(X_USER_ID_HEADER)
-    if not oidc_user_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User identity required",
-        )
-
-    profile = get_or_create_profile(session, oidc_user_id, request)
+    profile = get_or_create_profile(session, caller_id, request)
     return UserProfileWithNodes(
         id=profile.id,
         user_id=profile.user_id,
@@ -160,22 +156,22 @@ def get_my_profile(
 @router.get("/profile/{profile_id}")
 def get_profile(
     profile_id: str,
+    caller_id: OptionalUserIdentity,
     request: Request,
     session: DbSession,
 ) -> UserProfilePublicWithNodes | UserProfileWithNodes:
     """Get a user profile by UUID.
 
     Public access is allowed for viewing any profile. If the caller is the
-    owner (authenticated with matching user_id), the full profile including
-    user_id is returned and the profile is auto-created if missing.
+    owner (authenticated with a valid API key and matching proxy-injected
+    user_id), the full profile including user_id is returned and the
+    profile is auto-created if missing.
     """
-    oidc_user_id = request.headers.get(X_USER_ID_HEADER)
-
-    if oidc_user_id:
-        caller_query = select(UserProfile).where(UserProfile.user_id == oidc_user_id)
+    if caller_id:
+        caller_query = select(UserProfile).where(UserProfile.user_id == caller_id)
         caller_profile = session.execute(caller_query).scalar_one_or_none()
         if caller_profile and str(caller_profile.id) == str(profile_id):
-            profile = get_or_create_profile(session, oidc_user_id, request)
+            profile = get_or_create_profile(session, caller_id, request)
             return UserProfileWithNodes(
                 id=profile.id,
                 user_id=profile.user_id,

--- a/src/meshcore_hub/common/config.py
+++ b/src/meshcore_hub/common/config.py
@@ -417,6 +417,17 @@ class APISettings(CommonSettings):
         default=None, description="Admin API key (full access)"
     )
 
+    # Metrics endpoint
+    metrics_public: bool = Field(
+        default=False,
+        description=(
+            "Allow unauthenticated access to /metrics when no API read key "
+            "is configured. Defaults to false (deny): set API_READ_KEY (and "
+            "scrape with Basic auth user 'metrics') or set this flag to "
+            "expose metrics without authentication."
+        ),
+    )
+
     # Redis cache
     redis_enabled: bool = Field(
         default=False, description="Enable Redis API response caching"
@@ -496,6 +507,23 @@ class WebSettings(CommonSettings):
     web_debug: bool = Field(
         default=False,
         description="Enable debug mode in the web dashboard",
+    )
+
+    # Security headers / Content-Security-Policy
+    web_security_headers: bool = Field(
+        default=True,
+        description=(
+            "Emit security headers (X-Content-Type-Options, X-Frame-Options, "
+            "Referrer-Policy, Permissions-Policy) and a nonce-based "
+            "Content-Security-Policy on web responses"
+        ),
+    )
+    web_csp_extra: Optional[str] = Field(
+        default=None,
+        description=(
+            "Extra CSP directives appended to the default policy "
+            '(e.g. "img-src https://tiles.example.com")'
+        ),
     )
 
     # OIDC / OAuth2 authentication

--- a/src/meshcore_hub/web/app.py
+++ b/src/meshcore_hub/web/app.py
@@ -20,7 +20,10 @@ from meshcore_hub import __version__
 from meshcore_hub.collector.letsmesh_decoder import LetsMeshPacketDecoder
 from meshcore_hub.common.i18n import load_locale, t
 from meshcore_hub.common.schemas import RadioConfig
-from meshcore_hub.web.middleware import CacheControlMiddleware
+from meshcore_hub.web.middleware import (
+    CacheControlMiddleware,
+    SecurityHeadersMiddleware,
+)
 from meshcore_hub.web.oidc import (
     get_session_roles,
     get_session_user,
@@ -546,12 +549,24 @@ def create_app(
 
     # Add cache control headers based on resource type
     app.add_middleware(CacheControlMiddleware)
+    # Security headers + nonce-based CSP (kill switch via WEB_SECURITY_HEADERS)
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        enabled=settings.web_security_headers,
+        csp_extra=settings.web_csp_extra,
+    )
 
     # OIDC / session middleware
     if settings.oidc_enabled:
+        if not settings.oidc_session_secret:
+            raise RuntimeError(
+                "OIDC_SESSION_SECRET must be set when OIDC is enabled "
+                "(OIDC_ENABLED=true). Generate one with: "
+                'python -c "import secrets; print(secrets.token_urlsafe(48))"'
+            )
         app.add_middleware(
             SessionMiddleware,
-            secret_key=settings.oidc_session_secret or "insecure-dev-secret",
+            secret_key=settings.oidc_session_secret,
             session_cookie="meshcore-session",
             max_age=settings.oidc_session_max_age,
             same_site="lax",
@@ -921,6 +936,28 @@ def create_app(
         """Return node location data as JSON for the map."""
         if not request.app.state.features.get("map", True):
             return JSONResponse({"detail": "Map feature is disabled"}, status_code=404)
+
+        # Resolve the viewer's identity/roles exactly like the API proxy so
+        # the per-endpoint access mapping applies to this server-side
+        # profiles fetch too. Without this, /map/data would leak profile
+        # data to viewers the proxy would deny at /api/v1/user/profiles.
+        oidc_enabled = getattr(request.app.state, "oidc_enabled", False)
+        viewer_user_id: str | None = None
+        viewer_roles: frozenset[str] = frozenset()
+        if oidc_enabled:
+            user = get_session_user(request)
+            viewer_user_id = user.get("sub") if user else None
+            roles_claim = getattr(request.app.state, "oidc_roles_claim", "roles")
+            viewer_roles = frozenset(get_session_roles(request, roles_claim))
+        profiles_allowed = check_api_access(
+            "v1/user/profiles",
+            "GET",
+            oidc_enabled,
+            viewer_roles,
+            user_id=viewer_user_id,
+            mapping=request.app.state.endpoint_access,
+        )
+
         nodes_with_location: list[dict[str, Any]] = []
         profiles_by_id: dict[str, dict[str, Any]] = {}
         error: str | None = None
@@ -928,16 +965,17 @@ def create_app(
         nodes_with_coords = 0
 
         try:
-            profile_items, _, _ = await _fetch_all_pages(
-                request.app.state.http_client, "/api/v1/user/profiles"
-            )
-            for profile in profile_items:
-                profiles_by_id[profile["id"]] = {
-                    "id": profile.get("id"),
-                    "name": profile.get("name"),
-                    "callsign": profile.get("callsign"),
-                    "roles": profile.get("roles", []),
-                }
+            if profiles_allowed:
+                profile_items, _, _ = await _fetch_all_pages(
+                    request.app.state.http_client, "/api/v1/user/profiles"
+                )
+                for profile in profile_items:
+                    profiles_by_id[profile["id"]] = {
+                        "id": profile.get("id"),
+                        "name": profile.get("name"),
+                        "callsign": profile.get("callsign"),
+                        "roles": profile.get("roles", []),
+                    }
 
             # Fetch all nodes from the API, following pagination. The API caps
             # limit at 500 and sorts last_seen desc, so a single request only
@@ -1043,7 +1081,7 @@ def create_app(
                 "lon": sum(n["lon"] for n in adopted_nodes) / len(adopted_nodes),
             }
 
-        return JSONResponse(
+        response = JSONResponse(
             {
                 "nodes": nodes_with_location,
                 "profiles": list(profiles_by_id.values()),
@@ -1057,6 +1095,12 @@ def create_app(
                 },
             }
         )
+        # With OIDC enabled the payload can vary by viewer (profiles are
+        # access-gated), so shared caches must not store it. The middleware
+        # honors an explicitly preset Cache-Control header.
+        if oidc_enabled:
+            response.headers["cache-control"] = "private, max-age=300"
+        return response
 
     # --- Custom Pages API ---
     @app.get("/spa/pages/{slug}", tags=["SPA"])
@@ -1334,6 +1378,7 @@ def create_app(
                 "config_json": config_json,
                 "asset_app_js": request.app.state.asset_app_js,
                 "asset_app_css": request.app.state.asset_app_css,
+                "csp_nonce": getattr(request.state, "csp_nonce", None),
             },
         )
 

--- a/src/meshcore_hub/web/middleware.py
+++ b/src/meshcore_hub/web/middleware.py
@@ -1,5 +1,6 @@
-"""HTTP caching middleware for the web component."""
+"""HTTP caching and security header middleware for the web component."""
 
+import secrets
 from collections.abc import Awaitable, Callable
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -89,5 +90,84 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
         # SPA shell HTML (catch-all for client-side routes) - no cache
         elif response.headers.get("content-type", "").startswith("text/html"):
             response.headers["cache-control"] = "no-cache, public"
+
+        return response
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Middleware adding security headers and a nonce-based CSP to responses.
+
+    Generates a per-request CSP nonce, exposes it to handlers via
+    ``request.state.csp_nonce`` (the SPA shell template applies it to its
+    inline scripts), and sets standard hardening headers plus a
+    Content-Security-Policy on every response.
+
+    Notes on the policy:
+      - ``style-src 'unsafe-inline'``: the SPA shell conditionally emits one
+        small inline ``<style>`` block; style injection is low-risk.
+      - ``img-src ... https:``: custom markdown pages may embed external
+        https images; map tiles load from *.tile.openstreetmap.org.
+      - ``script-src`` allows only same-origin scripts plus nonce'd inline
+        scripts (theme bootstrap + ``window.__APP_CONFIG__``).
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        enabled: bool = True,
+        csp_extra: str | None = None,
+    ) -> None:
+        """Initialize the middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            enabled: When False, skip all header setting (kill switch).
+            csp_extra: Extra CSP directives appended to the default policy.
+        """
+        super().__init__(app)
+        self.enabled = enabled
+        self.csp_extra = csp_extra.strip().rstrip(";") if csp_extra else None
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Process the request and add security headers to the response.
+
+        Args:
+            request: The incoming HTTP request.
+            call_next: The next middleware or route handler.
+
+        Returns:
+            The response with security headers added.
+        """
+        nonce = secrets.token_urlsafe(16)
+        request.state.csp_nonce = nonce
+
+        response: Response = await call_next(request)
+
+        if self.enabled:
+            csp = (
+                "default-src 'self'; "
+                f"script-src 'self' 'nonce-{nonce}'; "
+                "style-src 'self' 'unsafe-inline'; "
+                "img-src 'self' data: https:; "
+                "font-src 'self'; "
+                "connect-src 'self'; "
+                "object-src 'none'; "
+                "base-uri 'self'; "
+                "form-action 'self'; "
+                "frame-ancestors 'none'"
+            )
+            if self.csp_extra:
+                csp = f"{csp}; {self.csp_extra}"
+            response.headers["content-security-policy"] = csp
+            response.headers["x-content-type-options"] = "nosniff"
+            response.headers["x-frame-options"] = "DENY"
+            response.headers["referrer-policy"] = "strict-origin-when-cross-origin"
+            response.headers["permissions-policy"] = (
+                "camera=(), microphone=(), geolocation=()"
+            )
 
         return response

--- a/src/meshcore_hub/web/templates/spa.html
+++ b/src/meshcore_hub/web/templates/spa.html
@@ -6,7 +6,7 @@
     <title>{{ network_name }}</title>
 
     <!-- Theme initialization (before CSS to prevent flash) -->
-    <script>
+    <script nonce="{{ csp_nonce }}">
         (function() {
             var theme = localStorage.getItem('meshcore-theme');
             if (theme) document.documentElement.setAttribute('data-theme', theme);
@@ -57,7 +57,7 @@
     <div id="app" class="flex-1 flex flex-col"></div>
 
     <!-- Embedded app configuration -->
-    <script>
+    <script nonce="{{ csp_nonce }}">
         window.__APP_CONFIG__ = {{ config_json|safe }};
     </script>
 

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -176,6 +176,9 @@ def app_no_auth(db_url, api_db_engine, mock_mqtt, mock_db_manager):
         database_url=db_url,
         read_key=None,
         admin_key=None,
+        # /metrics denies unauthenticated access by default; the no-auth
+        # app opts in so data-shape tests keep working without a key.
+        metrics_public=True,
     )
     _wire_overrides(app, api_db_engine, mock_mqtt, mock_db_manager)
     yield app

--- a/tests/test_api/test_app_factory.py
+++ b/tests/test_api/test_app_factory.py
@@ -1,6 +1,7 @@
 """Tests for the environment-driven app factory used by multi-worker runs."""
 
 import pytest
+from starlette.middleware.cors import CORSMiddleware
 
 from meshcore_hub.api.app import create_app_from_env
 
@@ -17,6 +18,7 @@ _FACTORY_ENV = [
     "CORS_ORIGINS",
     "METRICS_ENABLED",
     "METRICS_CACHE_TTL",
+    "METRICS_PUBLIC",
 ]
 
 
@@ -91,3 +93,44 @@ def test_factory_metrics_disabled_via_env(clean_env):
     clean_env.setenv("METRICS_ENABLED", "false")
     app = create_app_from_env()
     assert "/metrics" not in _served_paths(app)
+
+
+def _cors_middleware(app):
+    """Return the CORSMiddleware Middleware entry for the app."""
+    for middleware in app.user_middleware:
+        if middleware.cls is CORSMiddleware:
+            return middleware
+    raise AssertionError("CORSMiddleware not installed")
+
+
+def test_factory_default_cors_wildcard_without_credentials(clean_env):
+    """Unset CORS_ORIGINS keeps the wildcard but disables credentials."""
+    app = create_app_from_env()
+    cors = _cors_middleware(app)
+    assert cors.kwargs["allow_origins"] == ["*"]
+    assert cors.kwargs["allow_credentials"] is False
+
+
+def test_factory_explicit_origins_allow_credentials(clean_env):
+    """Explicit CORS_ORIGINS lists keep credentials enabled."""
+    clean_env.setenv("CORS_ORIGINS", "https://mesh.example.com,https://web.example.com")
+    app = create_app_from_env()
+    cors = _cors_middleware(app)
+    assert cors.kwargs["allow_origins"] == [
+        "https://mesh.example.com",
+        "https://web.example.com",
+    ]
+    assert cors.kwargs["allow_credentials"] is True
+
+
+def test_factory_metrics_public_defaults_deny(clean_env):
+    """METRICS_PUBLIC unset means /metrics denies unauthenticated access."""
+    app = create_app_from_env()
+    assert app.state.metrics_public is False
+
+
+def test_factory_metrics_public_via_env(clean_env):
+    """METRICS_PUBLIC=true opts into unauthenticated metrics."""
+    clean_env.setenv("METRICS_PUBLIC", "true")
+    app = create_app_from_env()
+    assert app.state.metrics_public is True

--- a/tests/test_api/test_metrics.py
+++ b/tests/test_api/test_metrics.py
@@ -76,11 +76,29 @@ class TestMetricsEndpoint:
 class TestMetricsAuth:
     """Tests for metrics endpoint authentication."""
 
-    def test_no_auth_when_no_read_key(self, client_no_auth):
-        """Test that no auth is required when no read key is configured."""
+    def test_public_when_no_read_key_and_opted_in(self, client_no_auth):
+        """Test that no auth is required when METRICS_PUBLIC is set and no key."""
         _clear_metrics_cache()
         response = client_no_auth.get("/metrics")
         assert response.status_code == 200
+
+    def test_deny_by_default_when_no_read_key(
+        self, test_db_path, api_db_engine, mock_mqtt, mock_db_manager
+    ):
+        """Unauthenticated /metrics is denied when no key is configured."""
+        db_url = f"sqlite:///{test_db_path}"
+
+        with patch("meshcore_hub.api.app._db_manager", mock_db_manager):
+            app = create_app(
+                database_url=db_url,
+                read_key=None,
+                admin_key=None,
+                metrics_public=False,
+            )
+            client = TestClient(app, raise_server_exceptions=True)
+            response = client.get("/metrics")
+            assert response.status_code == 401
+            assert "WWW-Authenticate" in response.headers
 
     def test_401_when_read_key_set_no_auth(self, client_with_auth):
         """Test 401 when read key is set but no auth provided."""

--- a/tests/test_api/test_user_profiles.py
+++ b/tests/test_api/test_user_profiles.py
@@ -164,6 +164,35 @@ class TestGetMyProfile:
         response = client_no_auth.get("/api/v1/user/profile/me")
         assert response.status_code == 401
 
+    def test_get_my_profile_forged_header_rejected(self, client_with_auth):
+        """With API keys configured, X-User-Id alone must not be trusted."""
+        response = client_with_auth.get(
+            "/api/v1/user/profile/me",
+            headers=USER_HEADERS,
+        )
+        assert response.status_code == 401
+
+    def test_get_my_profile_invalid_key_rejected(self, client_with_auth):
+        """An invalid bearer key must not authenticate the identity header."""
+        response = client_with_auth.get(
+            "/api/v1/user/profile/me",
+            headers={**USER_HEADERS, "Authorization": "Bearer wrong-key"},
+        )
+        assert response.status_code == 401
+
+    def test_get_my_profile_valid_key_and_header(
+        self, client_with_auth, sample_user_profile
+    ):
+        """Valid API key + proxy-injected X-User-Id returns the full profile."""
+        response = client_with_auth.get(
+            "/api/v1/user/profile/me",
+            headers={**USER_HEADERS, "Authorization": "Bearer test-read-key"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["user_id"] == TEST_USER_ID
+        assert data["name"] == sample_user_profile.name
+
 
 class TestGetProfile:
     """Tests for GET /user/profile/{profile_id} endpoint."""
@@ -239,6 +268,38 @@ class TestGetProfile:
             "/api/v1/user/profile/00000000-0000-0000-0000-000000000000",
         )
         assert response.status_code == 404
+
+    def test_get_profile_forged_header_rejected(
+        self, client_with_auth, sample_user_profile
+    ):
+        """Forged X-User-Id without a valid key must not reveal user_id."""
+        response = client_with_auth.get(
+            f"/api/v1/user/profile/{sample_user_profile.id}",
+            headers=USER_HEADERS,
+        )
+        assert response.status_code == 401
+
+    def test_get_profile_owner_with_valid_key_sees_user_id(
+        self, client_with_auth, sample_user_profile
+    ):
+        """Valid key + matching identity header returns the full profile."""
+        response = client_with_auth.get(
+            f"/api/v1/user/profile/{sample_user_profile.id}",
+            headers={**USER_HEADERS, "Authorization": "Bearer test-read-key"},
+        )
+        assert response.status_code == 200
+        assert response.json()["user_id"] == TEST_USER_ID
+
+    def test_get_profile_public_with_valid_key_no_identity(
+        self, client_with_auth, sample_user_profile
+    ):
+        """Valid key without identity headers returns the public shape."""
+        response = client_with_auth.get(
+            f"/api/v1/user/profile/{sample_user_profile.id}",
+            headers={"Authorization": "Bearer test-read-key"},
+        )
+        assert response.status_code == 200
+        assert "user_id" not in response.json()
 
 
 class TestUpdateProfile:

--- a/tests/test_web/test_map.py
+++ b/tests/test_web/test_map.py
@@ -1,10 +1,11 @@
 """Tests for the map page routes."""
 
 from typing import Any
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from tests.test_web.conftest import MockHttpClient
+from tests.test_web.conftest import MEMBER_USER, MockHttpClient
 
 
 class TestMapPage:
@@ -84,6 +85,89 @@ class TestMapDataEndpoint:
         # Node One has no location tags, so should not appear
         node_names = [n["name"] for n in nodes]
         assert "Node One" not in node_names
+
+
+class TestMapDataProfilesAccess:
+    """Tests for viewer-gated profile data in /map/data."""
+
+    PROFILES_PAYLOAD = {
+        "items": [
+            {
+                "id": "profile-1",
+                "name": "Op One",
+                "callsign": "OP1ABC",
+                "roles": ["operator"],
+            }
+        ],
+        "total": 1,
+    }
+
+    @staticmethod
+    def _restrict_profiles(web_app: Any) -> None:
+        """Restrict GET v1/user/profiles to the member role."""
+        web_app.state.endpoint_access["v1/user/profiles"]["GET"] = frozenset({"member"})
+
+    def test_restricted_profiles_hidden_from_anonymous(
+        self, web_app_with_oidc: Any, mock_http_client: MockHttpClient
+    ) -> None:
+        """Anonymous viewers get no profiles when the mapping restricts them."""
+        self._restrict_profiles(web_app_with_oidc)
+        web_app_with_oidc.state.http_client = mock_http_client
+
+        client = TestClient(web_app_with_oidc, raise_server_exceptions=True)
+        response = client.get("/map/data")
+
+        assert response.status_code == 200
+        assert response.json()["profiles"] == []
+        # Viewer-dependent payload must never be publicly cacheable
+        assert "private" in response.headers["cache-control"]
+
+    def test_restricted_profiles_visible_to_member(
+        self, web_app_with_oidc: Any, mock_http_client: MockHttpClient
+    ) -> None:
+        """Viewers with the required role still receive profiles."""
+        self._restrict_profiles(web_app_with_oidc)
+        mock_http_client.set_response(
+            "GET", "/api/v1/user/profiles", json_data=self.PROFILES_PAYLOAD
+        )
+        web_app_with_oidc.state.http_client = mock_http_client
+
+        with (
+            patch("meshcore_hub.web.app.get_session_user", return_value=MEMBER_USER),
+            patch("meshcore_hub.web.oidc.get_session_user", return_value=MEMBER_USER),
+        ):
+            client = TestClient(web_app_with_oidc, raise_server_exceptions=True)
+            response = client.get("/map/data")
+
+        assert response.status_code == 200
+        profiles = response.json()["profiles"]
+        assert len(profiles) == 1
+        assert profiles[0]["name"] == "Op One"
+        assert "private" in response.headers["cache-control"]
+
+    def test_open_mapping_serves_profiles_to_anonymous(
+        self, web_app_with_oidc: Any, mock_http_client: MockHttpClient
+    ) -> None:
+        """Default open mapping serves profiles even to anonymous viewers."""
+        mock_http_client.set_response(
+            "GET", "/api/v1/user/profiles", json_data=self.PROFILES_PAYLOAD
+        )
+        web_app_with_oidc.state.http_client = mock_http_client
+
+        client = TestClient(web_app_with_oidc, raise_server_exceptions=True)
+        response = client.get("/map/data")
+
+        assert response.status_code == 200
+        assert len(response.json()["profiles"]) == 1
+        # OIDC enabled => payload may vary by viewer; keep it private
+        assert "private" in response.headers["cache-control"]
+
+    def test_oidc_disabled_keeps_public_cache(self, client: TestClient) -> None:
+        """Without OIDC the payload is identical for everyone; public is safe."""
+        response = client.get("/map/data")
+
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "public, max-age=300"
 
 
 class TestMapDataAPIErrors:

--- a/tests/test_web/test_oidc.py
+++ b/tests/test_web/test_oidc.py
@@ -4,9 +4,32 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from meshcore_hub.web.oidc import init_oidc, strip_userinfo
+
+
+class TestSessionSecretRequired:
+    """OIDC requires an explicit session signing secret (no insecure fallback)."""
+
+    def test_missing_secret_fails_startup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OIDC enabled without OIDC_SESSION_SECRET must refuse to start."""
+        from meshcore_hub.common.config import get_web_settings
+        from meshcore_hub.web.app import create_app as create_web_app
+
+        real_settings = get_web_settings()
+        monkeypatch.setattr(
+            "meshcore_hub.common.config.get_web_settings",
+            lambda: real_settings.model_copy(
+                update={"oidc_enabled": True, "oidc_session_secret": None}
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="OIDC_SESSION_SECRET"):
+            create_web_app(api_url="http://localhost:8000")
 
 
 class TestOIDCSettingsValidation:

--- a/tests/test_web/test_security_headers.py
+++ b/tests/test_web/test_security_headers.py
@@ -1,0 +1,116 @@
+"""Tests for web security headers and CSP nonce middleware."""
+
+import re
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from meshcore_hub.web.app import create_app
+from tests.test_web.conftest import ALL_FEATURES_ENABLED, MockHttpClient
+
+_NONCE_RE = re.compile(r"nonce-([A-Za-z0-9_-]{16,})")
+
+
+def _make_app(**settings_overrides: Any) -> Any:
+    """Build a web app with the mock HTTP client and settings overrides."""
+    import meshcore_hub.common.config as config_module
+
+    original_get_settings = config_module.get_web_settings
+
+    try:
+        if settings_overrides:
+            config_module.get_web_settings = lambda: original_get_settings().model_copy(
+                update=settings_overrides
+            )
+        app = create_app(
+            api_url="http://localhost:8000",
+            api_key="test-api-key",
+            network_name="Test Network",
+            features=ALL_FEATURES_ENABLED,
+        )
+    finally:
+        config_module.get_web_settings = original_get_settings
+
+    app.state.http_client = MockHttpClient()
+    return app
+
+
+class TestSecurityHeaders:
+    """Security headers are applied to web responses."""
+
+    def test_hardening_headers_present(self) -> None:
+        client = TestClient(_make_app(), raise_server_exceptions=True)
+        response = client.get("/")
+        assert response.headers["x-content-type-options"] == "nosniff"
+        assert response.headers["x-frame-options"] == "DENY"
+        assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+        assert "geolocation=()" in response.headers["permissions-policy"]
+
+    def test_csp_directives(self) -> None:
+        client = TestClient(_make_app(), raise_server_exceptions=True)
+        csp = client.get("/").headers["content-security-policy"]
+        assert csp.startswith("default-src 'self'")
+        assert "script-src 'self' 'nonce-" in csp
+        assert "style-src 'self' 'unsafe-inline'" in csp
+        assert "img-src 'self' data: https:" in csp
+        assert "connect-src 'self'" in csp
+        assert "object-src 'none'" in csp
+        assert "base-uri 'self'" in csp
+        assert "form-action 'self'" in csp
+        assert "frame-ancestors 'none'" in csp
+
+    def test_csp_extra_setting_appended(self) -> None:
+        app = _make_app(web_csp_extra="img-src https://tiles.example.com")
+        csp = (
+            TestClient(app, raise_server_exceptions=True)
+            .get("/")
+            .headers["content-security-policy"]
+        )
+        assert csp.endswith("img-src https://tiles.example.com")
+
+    def test_inline_scripts_carry_matching_nonce(self) -> None:
+        client = TestClient(_make_app(), raise_server_exceptions=True)
+        response = client.get("/")
+        csp = response.headers["content-security-policy"]
+        header_nonce = _NONCE_RE.search(csp)
+        assert header_nonce is not None
+
+        html = response.text
+        nonce_attrs = re.findall(r'<script nonce="([^"]+)"', html)
+        # Theme bootstrap + __APP_CONFIG__ scripts both carry the nonce
+        assert len(nonce_attrs) == 2
+        assert all(n == header_nonce.group(1) for n in nonce_attrs)
+        # No un-nonced inline scripts remain (external src= scripts are
+        # covered by script-src 'self')
+        inline = re.findall(r"<script(?![^>]*(?:nonce|src=))[^>]*>", html)
+        assert inline == []
+
+    def test_nonce_rotates_per_request(self) -> None:
+        client = TestClient(_make_app(), raise_server_exceptions=True)
+        csp1 = client.get("/").headers["content-security-policy"]
+        csp2 = client.get("/").headers["content-security-policy"]
+        nonce1 = _NONCE_RE.search(csp1)
+        nonce2 = _NONCE_RE.search(csp2)
+        assert nonce1 is not None and nonce2 is not None
+        assert nonce1.group(1) != nonce2.group(1)
+
+    def test_headers_on_non_html_routes(self) -> None:
+        client = TestClient(_make_app(), raise_server_exceptions=True)
+        response = client.get("/health")
+        assert response.headers["x-content-type-options"] == "nosniff"
+        assert "content-security-policy" in response.headers
+
+        map_response = client.get("/map/data")
+        assert map_response.headers["x-frame-options"] == "DENY"
+
+
+class TestSecurityHeadersKillSwitch:
+    """WEB_SECURITY_HEADERS=false disables all header setting."""
+
+    def test_no_headers_when_disabled(self) -> None:
+        app = _make_app(web_security_headers=False)
+        client = TestClient(app, raise_server_exceptions=True)
+        response = client.get("/")
+        assert "content-security-policy" not in response.headers
+        assert "x-frame-options" not in response.headers
+        assert "x-content-type-options" not in response.headers


### PR DESCRIPTION
## Summary

Security review follow-up: four fixes tightening default posture. Two are **breaking** for existing deployments — see `docs/upgrading.md` for the full entry.

### Fixes

1. **`/map/data` follows the endpoint access model** — the server-side map aggregation now resolves the viewer's OIDC session and applies the same `check_api_access` mapping as the API proxy before fetching profiles. Deployments that restrict `v1/user/profiles` no longer leak profile data (names, callsigns, roles) through `/map/data`; with OIDC enabled the response is `Cache-Control: private` since the payload can vary by viewer.
2. **Key-validated identity headers** — `GET /user/profile/me` now uses `RequireUserOwner`, and the owner branch of `GET /user/profile/{id}` uses a new `optional_user_identity` dependency. A bare forged `X-User-Id` no longer reveals the full profile incl. the OIDC `sub` when API keys are configured.
3. **Fail-closed defaults**
   - ⚠️ **Breaking:** `OIDC_SESSION_SECRET` is now **mandatory** when `OIDC_ENABLED=true` — the web service refuses to start instead of falling back to the forgeable hard-coded `insecure-dev-secret`
   - ⚠️ **Breaking:** `/metrics` **denies unauthenticated access by default** when no `API_READ_KEY` is set (it exports node names, public keys, role counts and is often exposed via reverse proxy). Opt back in with `METRICS_PUBLIC=true`, or scrape with Basic auth (user `metrics`, password = read key)
   - CORS: unset `CORS_ORIGINS` keeps the `*` wildcard for external API consumers but no longer sets `allow-credentials` (invalid combination in browsers anyway) + logs a warning
4. **Security headers + CSP** — new `SecurityHeadersMiddleware` on the web tier (`X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`) with a per-request **nonce-based CSP** applied to the `spa.html` inline scripts. Kill switch: `WEB_SECURITY_HEADERS=false`; custom tile hosts etc. via `WEB_CSP_EXTRA`. The API emits `nosniff`.

### Deployment notes

- OIDC-enabled stacks without a session secret will refuse to boot → generate one with `python -c "import secrets; print(secrets.token_urlsafe(48))"`
- Metrics scrapers will see 401s until they use Basic auth or `METRICS_PUBLIC=true`
- If a reverse proxy strips headers or injects inline scripts, verify the CSP nonce still matches

## Test plan

- [x] `pytest -nauto --no-cov` — 1,537 passed (new: forged-header profile tests, map gating tests, security-header/nonce tests, secret hard-fail test, metrics default-deny, CORS factory tests)
- [x] `pre-commit run --all-files` — clean
- [x] `npx tsc --noEmit` + `npm run test:frontend` — 339 passed (no frontend changes required; `MapPage` already tolerates empty profiles)
- [ ] Manual: build + run the stack with OIDC enabled (user builds manually per AGENTS.md)