### PR TITLE
fix: silent config drops, metrics event-loop stall, and route/decoder bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ images**; the user does.
 
 ```bash
 npx playwright install chromium        # one-time browser binary (host)
+sudo npx playwright install-deps chromium  # one-time system libs (Debian: nspr/nss/alsa/atk/gbm/X11)
 make e2e-build && make e2e-up          # user: build + start mqtt/pg/migrate/collector/api/web
 make e2e-test                          # user: seeds via e2e/seed_data.py, then runs the suite
 make e2e-down                          # user: tear down (destroys the throwaway DB)

--- a/src/meshcore_hub/api/app.py
+++ b/src/meshcore_hub/api/app.py
@@ -95,6 +95,9 @@ def create_app(
     api_cache_control_enabled: bool = True,
     spam_detection_enabled: bool = False,
     spam_score_threshold: float = 0.65,
+    oidc_role_admin: str = "admin",
+    oidc_role_operator: str = "operator",
+    oidc_role_member: str = "member",
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -125,6 +128,11 @@ def create_app(
             /routes/{id} detail, and per-route health history
         api_cache_control_enabled: Emit HTTP Cache-Control on /api/v1/* and
             ETag/If-None-Match handling on @cached endpoints.
+        spam_detection_enabled: Hide spam-flagged messages in API responses.
+        spam_score_threshold: Score at/above which messages are treated as spam.
+        oidc_role_admin: IdP role name mapping to admin access.
+        oidc_role_operator: IdP role name mapping to operator access.
+        oidc_role_member: IdP role name mapping to member access.
 
     Returns:
         Configured FastAPI application
@@ -164,6 +172,11 @@ def create_app(
     app.state.api_cache_control_enabled = api_cache_control_enabled
     app.state.spam_detection_enabled = spam_detection_enabled
     app.state.spam_score_threshold = spam_score_threshold
+    # OIDC role-name mapping used by auth/channel-visibility/tag/adoption
+    # authorization (mirrors the web tier's app.state.oidc_role_*).
+    app.state.oidc_role_admin = oidc_role_admin
+    app.state.oidc_role_operator = oidc_role_operator
+    app.state.oidc_role_member = oidc_role_member
 
     # Configure CORS. An unset CORS_ORIGINS keeps the wildcard default for
     # compatibility with external API consumers, but wildcard origins are
@@ -357,4 +370,7 @@ def create_app_from_env() -> FastAPI:
         api_cache_control_enabled=settings.api_cache_control_enabled,
         spam_detection_enabled=settings.spam_detection_enabled,
         spam_score_threshold=settings.spam_score_threshold,
+        oidc_role_admin=settings.oidc_role_admin,
+        oidc_role_operator=settings.oidc_role_operator,
+        oidc_role_member=settings.oidc_role_member,
     )

--- a/src/meshcore_hub/api/cli.py
+++ b/src/meshcore_hub/api/cli.py
@@ -308,6 +308,10 @@ def api(
             f"(dashboard: {redis_cache_ttl_dashboard}s)"
         )
     click.echo(f"API Cache-Control enabled: {api_cache_control_enabled}")
+    click.echo(
+        f"Spam detection: {settings.spam_detection_enabled} "
+        f"(threshold: {settings.spam_score_threshold})"
+    )
     click.echo(f"Reload mode: {reload}")
     click.echo(f"Workers: {workers}")
     click.echo("=" * 50)
@@ -371,6 +375,11 @@ def api(
             redis_cache_ttl=redis_cache_ttl,
             redis_cache_ttl_dashboard=redis_cache_ttl_dashboard,
             api_cache_control_enabled=api_cache_control_enabled,
+            spam_detection_enabled=settings.spam_detection_enabled,
+            spam_score_threshold=settings.spam_score_threshold,
+            oidc_role_admin=settings.oidc_role_admin,
+            oidc_role_operator=settings.oidc_role_operator,
+            oidc_role_member=settings.oidc_role_member,
         )
 
         click.echo("\nStarting API server...")

--- a/src/meshcore_hub/api/metrics.py
+++ b/src/meshcore_hub/api/metrics.py
@@ -4,6 +4,7 @@ import base64
 import hmac
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Request, Response
@@ -78,6 +79,7 @@ def collect_metrics(session: Any) -> bytes:
         Prometheus text exposition format as bytes
     """
     from meshcore_hub import __version__
+    from meshcore_hub.collector.routes import effective_clear_threshold
 
     registry = CollectorRegistry()
 
@@ -108,8 +110,6 @@ def collect_metrics(session: Any) -> bytes:
     )
     for window, hours in [("1h", 1), ("24h", 24), ("7d", 168), ("30d", 720)]:
         cutoff = time.time() - (hours * 3600)
-        from datetime import datetime, timezone
-
         cutoff_dt = datetime.fromtimestamp(cutoff, tz=timezone.utc)
         count = (
             session.execute(
@@ -368,8 +368,6 @@ def collect_metrics(session: Any) -> bytes:
         route_quality.labels(route=name).set(_QUALITY_VALUES.get(quality_str, 3))
         route_matched.labels(route=name).set(result.matched_count if result else 0)
         route_threshold.labels(route=name).set(route.packet_count_threshold)
-        from meshcore_hub.collector.routes import effective_clear_threshold
-
         route_clear.labels(route=name).set(effective_clear_threshold(route))
 
     output: bytes = generate_latest(registry)
@@ -377,9 +375,12 @@ def collect_metrics(session: Any) -> bytes:
 
 
 @router.get("/metrics")
-async def metrics(request: Request) -> Response:
+def metrics(request: Request) -> Response:
     """Prometheus metrics endpoint.
 
+    Sync (not async) on purpose: collection runs ~20 blocking DB queries, so
+    the handler must run in FastAPI's threadpool instead of stalling the
+    event loop.
     Returns metrics in Prometheus text exposition format.
     Supports HTTP Basic Auth with username 'metrics' and API read key as
     password. When no read key is configured, access is denied unless

--- a/src/meshcore_hub/collector/letsmesh_decoder.py
+++ b/src/meshcore_hub/collector/letsmesh_decoder.py
@@ -72,10 +72,13 @@ class LetsMeshPacketDecoder:
     def reload_keys(self, channel_keys: list[str]) -> None:
         """Reload channel keys from a new key list (thread-safe).
 
-        Rebuilds the key store and channel name map without discarding the
-        decode cache.  The state lock is held only during the atomic swap
-        of ``_key_store`` and ``_channel_names_by_hash``, not during key
-        normalization or KeyStore construction.
+        Rebuilds the key store and channel name map, discarding the decode
+        cache: cached negative results were produced under the previous key
+        set, and packets for a newly added channel key must be re-decoded
+        (otherwise the normalizer permanently drops them as undecodable).
+        The state lock is held only during the atomic swap of
+        ``_key_store``/``_channel_names_by_hash`` and the cache clear, not
+        during key normalization or KeyStore construction.
 
         Args:
             channel_keys: New list of channel key entries to load.
@@ -92,6 +95,7 @@ class LetsMeshPacketDecoder:
             self._channel_keys = new_keys
             self._channel_names_by_hash = new_names
             self._key_store = new_store
+            self._decode_cache.clear()
 
         logger.debug(
             "LetsMesh decoder reloaded: %d channel keys (%s)",

--- a/src/meshcore_hub/collector/routes.py
+++ b/src/meshcore_hub/collector/routes.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from meshcore_hub.common.models.node import Node
 from meshcore_hub.common.models.packet_path_hop import PacketPathHop
+from meshcore_hub.common.models.raw_packet import RawPacket
 from meshcore_hub.common.models.route import Route
 from meshcore_hub.common.models.route_recent_match import RouteRecentMatch
 from meshcore_hub.common.models.route_result import (
@@ -371,7 +372,7 @@ def _fetch_matching_hops(
     since: datetime,
     until: datetime,
     observer_ids: Optional[list[str]] = None,
-) -> dict[str, list[dict[str, Any]]]:
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Optional[int]]]:
     """Fetch only hops whose ``node_hash`` matches any of *prefixes*.
 
     Unlike :func:`fetch_candidate_paths` (which loads **all** hops for
@@ -380,6 +381,13 @@ def _fetch_matching_hops(
     inspects hops whose ``node_hash`` starts with an expected prefix, so
     filtering at the SQL level is semantically identical but returns far
     fewer rows.
+
+    Returns ``(paths, path_lens)`` where *paths* maps raw packet id to its
+    prefix-matching hops and *path_lens* maps raw packet id to the packet's
+    true total hop count (``RawPacket.path_len``, None when unset).  The
+    filtered hop lists must NOT be length-checked against a route's
+    ``max_path_length`` — callers use *path_lens* for that so history
+    evaluation agrees with snapshot evaluation.
     """
     prefix_ranges = []
     for prefix in dict.fromkeys(prefixes):
@@ -399,7 +407,9 @@ def _fetch_matching_hops(
             PacketPathHop.packet_hash,
             PacketPathHop.event_hash,
             PacketPathHop.received_at,
+            RawPacket.path_len,
         )
+        .join(RawPacket, RawPacket.id == PacketPathHop.raw_packet_id)
         .where(
             PacketPathHop.received_at >= since,
             PacketPathHop.received_at < until,
@@ -411,10 +421,12 @@ def _fetch_matching_hops(
         stmt = stmt.where(PacketPathHop.observer_node_id.in_(observer_ids))
 
     paths: dict[str, list[dict[str, Any]]] = {}
+    path_lens: dict[str, Optional[int]] = {}
     for row in session.execute(stmt).all():
         rp_id = row.raw_packet_id
         if rp_id not in paths:
             paths[rp_id] = []
+            path_lens[rp_id] = row.path_len
         paths[rp_id].append(
             {
                 "position": row.position,
@@ -424,7 +436,7 @@ def _fetch_matching_hops(
                 "received_at": row.received_at,
             }
         )
-    return paths
+    return paths, path_lens
 
 
 def _count_candidate_receptions(
@@ -699,8 +711,10 @@ def evaluate_route_history(
     # _subsequence_indices only inspects hops whose node_hash starts with
     # an expected prefix, so filtering at SQL level is semantically
     # identical but returns far fewer rows than loading all hops for
-    # matching raw packets.
-    all_paths = _fetch_matching_hops(
+    # matching raw packets.  The packets' true hop counts (path_lens) ride
+    # along so max_path_length can be applied to the FULL path length,
+    # exactly like snapshot evaluation.
+    all_paths, path_lens = _fetch_matching_hops(
         session, expected, window_start, window_end, observer_ids
     )
 
@@ -753,10 +767,17 @@ def evaluate_route_history(
     results: list[tuple[date, str, str, int]] = []
     for i in range(historical_days):
         matched_packets: set[str] = set()
-        for hops in day_paths[i].values():
-            if _match_hops(
-                hops, expected, route.max_hop_span, route.max_path_length, reversible
-            ):
+        for rp_id, hops in day_paths[i].items():
+            # max_path_length caps the packet's FULL hop count.  The
+            # filtered hop list cannot be used for this (it only contains
+            # prefix-matching hops), so check the true length first and
+            # keep the guard out of _match_hops.  Legacy rows without
+            # path_len are not rejected.
+            if route.max_path_length is not None:
+                true_len = path_lens.get(rp_id)
+                if true_len is not None and true_len > route.max_path_length:
+                    continue
+            if _match_hops(hops, expected, route.max_hop_span, None, reversible):
                 identity = _match_identity(hops)
                 if identity:
                     matched_packets.add(identity)

--- a/src/meshcore_hub/common/config.py
+++ b/src/meshcore_hub/common/config.py
@@ -172,6 +172,25 @@ class CommonSettings(BaseSettings):
         ),
     )
 
+    # OIDC role-name mapping shared by all components. The web tier resolves
+    # session roles against these names (app.state + ENDPOINT_ACCESS proxy);
+    # the API tier matches them for authorization, channel visibility, and
+    # role-filtered lists. Only the IdP claim parsing (oidc_roles_claim) is
+    # web-specific and stays on WebSettings.
+    oidc_role_admin: str = Field(
+        default="admin", description="IdP role name for admin access"
+    )
+    oidc_role_operator: str = Field(
+        default="operator", description="IdP role name for operator access"
+    )
+    oidc_role_member: str = Field(
+        default="member", description="IdP role name for member access"
+    )
+    oidc_role_test: str = Field(
+        default="test",
+        description="IdP role name for test users (excluded from public views)",
+    )
+
 
 class CollectorSettings(CommonSettings):
     """Settings for the Collector component."""
@@ -552,19 +571,8 @@ class WebSettings(CommonSettings):
     oidc_roles_claim: str = Field(
         default="roles", description="ID token claim containing user roles"
     )
-    oidc_role_admin: str = Field(
-        default="admin", description="IdP role name for admin access"
-    )
-    oidc_role_operator: str = Field(
-        default="operator", description="IdP role name for operator access"
-    )
-    oidc_role_member: str = Field(
-        default="member", description="IdP role name for member access"
-    )
-    oidc_role_test: str = Field(
-        default="test",
-        description="IdP role name for test users (excluded from public views)",
-    )
+    # Role-name mapping (oidc_role_admin/operator/member/test) is inherited
+    # from CommonSettings — shared with the API tier.
     oidc_session_secret: Optional[str] = Field(
         default=None, description="Secret key for signing session cookies"
     )

--- a/tests/test_api/test_app_factory.py
+++ b/tests/test_api/test_app_factory.py
@@ -19,6 +19,11 @@ _FACTORY_ENV = [
     "METRICS_ENABLED",
     "METRICS_CACHE_TTL",
     "METRICS_PUBLIC",
+    "SPAM_DETECTION_ENABLED",
+    "SPAM_SCORE_THRESHOLD",
+    "OIDC_ROLE_ADMIN",
+    "OIDC_ROLE_OPERATOR",
+    "OIDC_ROLE_MEMBER",
 ]
 
 
@@ -134,3 +139,44 @@ def test_factory_metrics_public_via_env(clean_env):
     clean_env.setenv("METRICS_PUBLIC", "true")
     app = create_app_from_env()
     assert app.state.metrics_public is True
+
+
+def test_factory_reads_spam_settings_from_env(clean_env):
+    """SPAM_DETECTION_ENABLED / SPAM_SCORE_THRESHOLD reach app.state so the
+    messages hide-filter actually runs when the feature is enabled."""
+    clean_env.setenv("SPAM_DETECTION_ENABLED", "true")
+    clean_env.setenv("SPAM_SCORE_THRESHOLD", "0.9")
+
+    app = create_app_from_env()
+
+    assert app.state.spam_detection_enabled is True
+    assert app.state.spam_score_threshold == 0.9
+
+
+def test_factory_spam_settings_default_off(clean_env):
+    """Without env config the feature stays dark (create_app default)."""
+    app = create_app_from_env()
+    assert app.state.spam_detection_enabled is False
+    assert app.state.spam_score_threshold == 0.65
+
+
+def test_factory_reads_oidc_role_names_from_env(clean_env):
+    """Custom OIDC_ROLE_* names reach app.state, matching the web tier, so
+    API authorization honors customized IdP role naming."""
+    clean_env.setenv("OIDC_ROLE_ADMIN", "superadmin")
+    clean_env.setenv("OIDC_ROLE_OPERATOR", "moderator")
+    clean_env.setenv("OIDC_ROLE_MEMBER", "user")
+
+    app = create_app_from_env()
+
+    assert app.state.oidc_role_admin == "superadmin"
+    assert app.state.oidc_role_operator == "moderator"
+    assert app.state.oidc_role_member == "user"
+
+
+def test_factory_oidc_role_names_default(clean_env):
+    """Default role names match the documented admin/operator/member."""
+    app = create_app_from_env()
+    assert app.state.oidc_role_admin == "admin"
+    assert app.state.oidc_role_operator == "operator"
+    assert app.state.oidc_role_member == "member"

--- a/tests/test_api/test_cli.py
+++ b/tests/test_api/test_cli.py
@@ -47,3 +47,31 @@ def test_api_workers_from_env_var():
     assert result.exit_code == 0
     _, kwargs = mock_run.call_args
     assert kwargs["workers"] == 2
+
+
+def test_api_single_process_passes_spam_and_role_settings():
+    """The single-process app must carry the env-configured spam + OIDC role
+    settings — previously this path dropped them, silently disabling the
+    spam hide-filter and custom role names (the env factory path was fine)."""
+    runner = CliRunner()
+    with patch("uvicorn.run") as mock_run:
+        result = runner.invoke(
+            api,
+            [],
+            env={
+                "SPAM_DETECTION_ENABLED": "true",
+                "SPAM_SCORE_THRESHOLD": "0.8",
+                "OIDC_ROLE_ADMIN": "superadmin",
+                "OIDC_ROLE_OPERATOR": "moderator",
+                "OIDC_ROLE_MEMBER": "user",
+            },
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    app = mock_run.call_args[0][0]
+    assert app.state.spam_detection_enabled is True
+    assert app.state.spam_score_threshold == 0.8
+    assert app.state.oidc_role_admin == "superadmin"
+    assert app.state.oidc_role_operator == "moderator"
+    assert app.state.oidc_role_member == "user"

--- a/tests/test_collector/test_letsmesh_decoder.py
+++ b/tests/test_collector/test_letsmesh_decoder.py
@@ -224,6 +224,34 @@ def test_reload_keys_with_empty_list_keeps_builtins() -> None:
     assert "EB50A1BCB3E4E5D7BF69A57C9DADA211" not in decoder._channel_keys
 
 
+def test_reload_keys_clears_decode_cache() -> None:
+    """Reload discards cached results (including negative ones) so packets
+    that were undecodable under the old key set are retried with the new
+    keys instead of being served from the cache forever."""
+    decoder = LetsMeshPacketDecoder()
+
+    undecoded = MagicMock()
+    undecoded.is_valid = False
+    undecoded.errors = ["no channel key"]
+
+    decoded_ok = MagicMock()
+    decoded_ok.is_valid = True
+    decoded_ok.to_dict.return_value = {"payloadType": 5}
+    decoded_ok.payload = {}
+
+    with patch(
+        "meshcore_hub.collector.letsmesh_decoder.MeshCoreDecoder.decode",
+        side_effect=[undecoded, decoded_ok],
+    ) as mock_decode:
+        assert decoder.decode_payload({"raw": "A1B2C3"}) is None
+
+        decoder.reload_keys(["chat=D0BDD6D71538138ED979EEC00D98AD97"])
+        decoded = decoder.decode_payload({"raw": "A1B2C3"})
+
+    assert decoded == {"payloadType": 5}
+    assert mock_decode.call_count == 2
+
+
 def test_enrich_payload_decoded_merges_attributes() -> None:
     """_enrich_payload_decoded merges payload object attributes into dict."""
     payload_obj = MagicMock()

--- a/tests/test_collector/test_routes.py
+++ b/tests/test_collector/test_routes.py
@@ -53,6 +53,7 @@ def _make_reception(
     path_hashes: list[str],
     received_at: datetime | None = None,
     event_hash: str | None = None,
+    path_len: int | None = None,
 ) -> str:
     """Insert a RawPacket + PacketPathHop rows for a test reception."""
     ts = received_at or _NOW
@@ -62,6 +63,7 @@ def _make_reception(
         observer_node_id=observer_node_id,
         packet_hash=packet_hash,
         event_hash=event_hash,
+        path_len=path_len if path_len is not None else len(path_hashes),
         received_at=ts,
     )
     db_session.add(rp)
@@ -90,6 +92,7 @@ def _make_route(
     threshold: int = 3,
     clear_bar: int | None = None,
     max_hop_span: int | None = None,
+    max_path_length: int | None = None,
     observers: list[Node] | None = None,
     enabled: bool = True,
     window_hours: int = 24,
@@ -102,6 +105,7 @@ def _make_route(
         packet_count_threshold=threshold,
         clear_threshold=clear_bar,
         max_hop_span=max_hop_span,
+        max_path_length=max_path_length,
         enabled=enabled,
         window_hours=window_hours,
         reversible=reversible,
@@ -1119,6 +1123,54 @@ class TestEvaluateRouteHistory:
         assert today_entry[0] == now.date()
         assert today_entry[3] == 0
         assert today_entry[1] == RouteQuality.UNKNOWN.value
+
+    def test_max_path_length_uses_true_hop_count(self, db_session):
+        """max_path_length must gate on the packet's FULL hop count so
+        history day buckets agree with snapshot evaluation.
+
+        The history fetch only loads prefix-matching hops; before the fix
+        the length guard ran on that filtered list, so a 6-hop packet with
+        only 2 matching hops slipped past max_path_length=3 in history
+        while being rejected by evaluate_route.
+        """
+        node_a = _make_node(db_session, "aa" + "0" * 62)
+        node_b = _make_node(db_session, "bb" + "0" * 62)
+        route = _make_route(
+            db_session, "R1", [node_a, node_b], threshold=1, max_path_length=3
+        )
+
+        now = datetime(2026, 7, 15, 12, 0, 0, tzinfo=timezone.utc)
+        yesterday = now - timedelta(days=1)
+
+        # 6 total hops, only 2 match the route prefixes (AA ... BB).
+        _make_reception(
+            db_session,
+            None,
+            "toolong",
+            ["AA", "11", "22", "33", "44", "BB"],
+            received_at=yesterday,
+            event_hash="ev-toolong",
+        )
+        # 3 total hops — within the cap.
+        _make_reception(
+            db_session,
+            None,
+            "okpkt",
+            ["AA", "12", "BB"],
+            received_at=yesterday,
+            event_hash="ev-ok",
+        )
+        db_session.commit()
+
+        results = evaluate_route_history(db_session, route, days=2, now=now)
+        assert results[-1][0] == yesterday.date()
+        assert results[-1][3] == 1  # only the within-cap packet matched
+
+        # Snapshot evaluation agrees: the long packet is rejected there too.
+        _state, _quality, matched = evaluate_route(
+            db_session, route, now - timedelta(days=2)
+        )
+        assert matched == 1
 
 
 class TestComputeAverageQuality:

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -30,6 +30,36 @@ class TestCommonSettings:
         assert settings.mqtt_transport.value == "websockets"
         assert settings.mqtt_ws_path == "/"
 
+    def test_oidc_role_names_shared_by_all_components(self) -> None:
+        """OIDC role-name mapping lives on CommonSettings so the API tier
+        resolves the same names as the web tier (authorization, channel
+        visibility, role-filtered lists)."""
+        settings = CommonSettings(
+            _env_file=None,
+            oidc_role_admin="superadmin",
+            oidc_role_operator="moderator",
+            oidc_role_member="user",
+            oidc_role_test="sandbox",
+        )
+
+        assert settings.oidc_role_admin == "superadmin"
+        assert settings.oidc_role_operator == "moderator"
+        assert settings.oidc_role_member == "user"
+        assert settings.oidc_role_test == "sandbox"
+
+        # Every component inherits the mapping (previously WebSettings-only).
+        for cls in (CollectorSettings, APISettings, WebSettings):
+            inherited = cls(_env_file=None, oidc_role_operator="moderator")
+            assert inherited.oidc_role_operator == "moderator"
+            assert inherited.oidc_role_admin == "admin"
+
+    def test_oidc_roles_claim_stays_web_specific(self) -> None:
+        """The IdP claim name is only parsed by the web tier."""
+        settings = APISettings(_env_file=None)
+
+        assert not hasattr(settings, "oidc_roles_claim")
+        assert WebSettings(_env_file=None).oidc_roles_claim == "roles"
+
 
 class TestCollectorSettings:
     """Tests for CollectorSettings."""


### PR DESCRIPTION
## Summary

Follow-up to the security-hardening pass: five correctness bugs found in a full codebase review, none security-related.

| # | Fix | Where |
|---|---|---|
| 1 | **Spam detection silently off in the default deployment** — the CLI single-process path never passed `spam_detection_enabled`/`spam_score_threshold` to `create_app()`, so the API-side hide-filter was dead while the collector kept scoring | `api/cli.py` |
| 2 | **Custom OIDC role names ignored by the API** — `oidc_role_admin/operator/member/test` moved from `WebSettings` to `CommonSettings` and wired onto API `app.state`; API authz, channel visibility, and tag/adoption checks previously matched hardcoded `admin`/`operator`/`member`. `oidc_roles_claim` stays web-only (no env-var changes) | `config.py`, `api/app.py`, `api/cli.py` |
| 3 | **`/metrics` blocked the event loop** — `async def` handler ran ~20 blocking DB queries inline; now sync `def` (threadpooled, like every other heavy handler) + hoisted fragile in-loop imports | `api/metrics.py` |
| 4 | **`max_path_length` inconsistent between snapshot and history** — history matched against the prefix-filtered hop list, so a 6-hop packet with 2 matching hops passed `max_path_length=3` that the snapshot evaluator rejected. `_fetch_matching_hops` now joins `RawPacket.path_len` and the guard uses the true hop count (NULL = legacy, not rejected) | `collector/routes.py` |
| 5 | **Decode cache not cleared on channel-key reload** — negatively-cached packets for a newly keyed channel were permanently dropped by the normalizer until cache churn; `reload_keys` now clears the cache | `collector/letsmesh_decoder.py` |

Also adds the missing `sudo npx playwright install-deps chromium` one-time step to AGENTS.md e2e setup.

## Tests

- New regression tests: CLI/env factory passthrough (spam + roles), role fields on all settings classes, 6-hop-vs-3-hop history/snapshot agreement, cache-clear-on-reload
- `pytest -nauto --no-cov`: **1546 passed**
- `pre-commit run --all-files`: clean (black/flake8/mypy/tsc)
- Playwright e2e against the throwaway stack: **41 passed** (1.5m)

No migrations, no compose/env changes.