### PR TITLE
Add Playwright e2e job to CI and upload test report artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,14 @@ jobs:
       - name: Unit tests
         run: npm run test:frontend
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: vitest-results
+          path: vitest-junit.xml
+          retention-days: 14
+
       - name: Build
         run: npm run build
 
@@ -92,6 +100,16 @@ jobs:
         run: |
           pytest -nauto --cov=meshcore_hub --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: pytest-results
+          path: |
+            junit.xml
+            coverage.xml
+          retention-days: 14
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         if: always()
@@ -107,6 +125,54 @@ jobs:
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install frontend deps
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Set up Python env for mint_session.py
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install itsdangerous
+
+      - name: Build e2e stack
+        run: docker compose -f e2e/docker-compose.test.yml build
+
+      - name: Start e2e stack
+        run: docker compose -f e2e/docker-compose.test.yml up -d --wait
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 14
 
   build:
     name: Build Package

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+junit.xml
+vitest-junit.xml
 coverage.xml
 *.cover
 *.py.cover

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "node build.js",
     "dev": "vite --config vite.config.ts",
-    "test:frontend": "vitest run",
+    "test:frontend": "vitest run --reporter=default --reporter=junit --outputFile.junit=vitest-junit.xml",
     "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "typecheck:e2e": "tsc -p e2e/tsconfig.json --noEmit"


### PR DESCRIPTION
## Summary

- Adds an `e2e` job to CI: builds and starts the self-contained Playwright stack (`e2e/docker-compose.test.yml` — ephemeral Postgres, isolated volumes) and runs the suite via `npm run test:e2e`. Runs in parallel with lint/test/frontend.
- Uploads test report artifacts on every run (`if: always()`, 14-day retention):
  - `playwright-report` — Playwright HTML report + traces/screenshots
  - `pytest-results` — `junit.xml` + `coverage.xml`
  - `vitest-results` — new `vitest-junit.xml` (built-in vitest junit reporter, no new deps)
- Gitignores `junit.xml` / `vitest-junit.xml`.

## Testing

- Vitest run verified locally: 341 tests pass, `vitest-junit.xml` produced.
- Pre-commit hooks pass; YAML validated.
- E2E flow mirrors the documented local workflow (`make e2e-build && make e2e-up && make e2e-test`); global setup seeds the DB, waits for readiness, and forges session cookies via a `.venv` with `itsdangerous`.