### PR TITLE
fix(compose): keep bundled postgres out of the core profile in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,10 +69,14 @@ DATA_HOME=./data
 # -----------------------------------------------------------------------------
 # Database (PostgreSQL — the only backend since v0.19)
 # -----------------------------------------------------------------------------
-# The bundled postgres container is part of the default `core` profile and
-# derives its POSTGRES_USER/PASSWORD/DB from DATABASE_USER/PASSWORD/NAME, so
-# a default `docker compose up` works with zero configuration. The default
-# password below is dev-only — override DATABASE_PASSWORD in production.
+# The bundled postgres container is a development convenience: it joins the
+# `core` profile via docker-compose.dev.yml (profiles merge across override
+# files) and derives its POSTGRES_USER/PASSWORD/DB from
+# DATABASE_USER/PASSWORD/NAME, so a default dev `docker compose up` works with
+# zero configuration. Production (docker-compose.prod.yml) does NOT start it —
+# point DATABASE_HOST at your shared/external instance (starting the bundled
+# container there would shadow a 'postgres' host on the same network). The
+# default password below is dev-only — override DATABASE_PASSWORD in production.
 #
 # See docs/database.md for the full reference: production role/database
 # provisioning, managed/external Postgres, and schema-per-instance (search_path)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Design notes when extending the suite:
 
 ## Database & Ops
 
-The database backend is **PostgreSQL** (the only backend since v0.19). The bundled container starts with the `core` compose profile — see `docs/database.md` for the full reference, production provisioning, and schema-per-instance setup. Backend tests also require Postgres: `make test-db-up` starts a throwaway instance on `127.0.0.1:55432` (or point `TEST_POSTGRES_URL` at your own).
+The database backend is **PostgreSQL** (the only backend since v0.19). The bundled container is dev-only: it joins the `core` compose profile via `docker-compose.dev.yml` (profiles union across override files), so the documented dev commands start it automatically — production (`docker-compose.prod.yml`) never starts it with `core`/`migrate`, so it cannot shadow a shared `postgres` host on the same network. See `docs/database.md` for the full reference, production provisioning, and schema-per-instance setup. Backend tests also require Postgres: `make test-db-up` starts a throwaway instance on `127.0.0.1:55432` (or point `TEST_POSTGRES_URL` at your own).
 
 ```bash
 # --- LOCAL (venv): author a migration against a local schema (NOT the dev DB)

--- a/README.md
+++ b/README.md
@@ -105,16 +105,20 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compos
 
 Service profiles:
 
-| Profile    | Services                        | Use Case                                  |
-| ---------- | ------------------------------- | ----------------------------------------- |
-| `all`      | mqtt, observer, migrate, collector, api, web | Everything on one host        |
-| `core`     | migrate, collector, api, web                 | Central server infrastructure |
-| `mqtt`     | meshcore-mqtt-broker            | Local MQTT broker (optional)              |
-| `observer` | packet capture observer         | Observes RF traffic and publishes to MQTT |
-| `seed`     | seed                            | One-time seed data import                 |
-| `migrate`  | migrate                         | One-time database migration               |
+| Profile    | Services                                                        | Use Case                                  |
+| ---------- | --------------------------------------------------------------- | ----------------------------------------- |
+| `all`      | postgres, redis, mqtt, observer, migrate, collector, api, web   | Everything on one host                    |
+| `core`     | postgres (dev override only), migrate, collector, api, web      | Central server infrastructure             |
+| `mqtt`     | meshcore-mqtt-broker                                            | Local MQTT broker (optional)              |
+| `cache`    | redis                                                           | Local Redis cache (optional)              |
+| `postgres` | postgres                                                        | Bundled database, standalone opt-in       |
+| `observer` | packet capture observer                                         | Observes RF traffic and publishes to MQTT |
+| `seed`     | seed                                                            | One-time seed data import                 |
+| `migrate`  | migrate                                                         | One-time database migration               |
 
 **Note:** Most deployments connect to an external MQTT broker. Add `--profile mqtt` only if you need a local broker. The `observer` profile runs [meshcore-packet-capture](https://github.com/agessaman/meshcore-packet-capture) to observe MeshCore RF traffic and publish decoded packets to MQTT.
+
+**Database note:** the bundled `postgres` container joins the `core` profile only when using `docker-compose.dev.yml` (profiles merge across override files), so the zero-config dev workflow is unchanged. Production (`docker-compose.prod.yml`) deliberately leaves it out — the bundled container's `postgres` network alias would shadow a shared instance of the same name on the same Docker network. Point the `DATABASE_*` variables at your shared/external instance, or opt in explicitly with `--profile postgres` / `--profile all`. See [docs/database.md](docs/database.md).
 
 ### Simple Self-Hosted Setup
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,16 @@ services:
   migrate:
     pull_policy: build
 
+  # Bundled dev database: unions 'core' into the base [all, postgres] profile
+  # list (profiles merge across files), so the documented dev workflow
+  # (`--profile core`, `make up`) still starts Postgres for zero-effort setup.
+  # Production uses docker-compose.prod.yml instead, which leaves 'core' out —
+  # the bundled container never starts there to shadow a shared instance named
+  # 'postgres' on the same network.
+  postgres:
+    profiles:
+      - core
+
   seed:
     pull_policy: build
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,13 @@
 # reverse proxy access (Traefik, Nginx, Caddy, etc.).
 # No ports are exposed directly — all traffic goes through the reverse proxy.
 #
+# NOTE: the bundled 'postgres' service is NOT started by the 'core' profile
+# with this override (that convenience is dev-only, via docker-compose.dev.yml).
+# Point the DATABASE_* variables at your shared/external instance instead —
+# starting the bundled container alongside it would shadow a 'postgres' host
+# on the same network. Opt in explicitly with `--profile postgres` (or
+# `--profile all`) if you really want the bundled database on this host.
+#
 # Prerequisites:
 #   docker network create proxy-net
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,8 +149,12 @@ services:
 
   # ==========================================================================
   # PostgreSQL - the database backend (the only one since v0.19)
-  # Part of the core/all profiles so a default `compose up` is zero-effort;
-  # the explicit 'postgres' profile also starts it standalone.
+  # Bundled development database: docker-compose.dev.yml unions 'core' into
+  # these profiles so a default dev `compose up` is zero-effort. Production
+  # (prod.yml) does NOT — pointing DATABASE_* at a shared/external instance
+  # while the bundled container also starts would shadow a 'postgres' host on
+  # the same network. Start it standalone with the explicit 'postgres'
+  # profile (or 'all') only when the bundled database is really wanted.
   # POSTGRES_* init vars derive from the same DATABASE_* values (single source
   # of truth); the schema itself is created by `db upgrade` (alembic).
   # The default password is dev-only — override DATABASE_PASSWORD in
@@ -161,7 +165,6 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-hub}-postgres
     profiles:
       - all
-      - core
       - postgres
     restart: unless-stopped
     environment:
@@ -458,9 +461,11 @@ services:
       - migrate
     restart: "no"
     depends_on:
+      # Optional: healthy when the bundled postgres is enabled (dev override),
+      # skipped when it is profile-inactive (production external database).
       postgres:
         condition: service_healthy
-        required: true
+        required: false
     volumes:
       - data:/data
     environment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,11 +34,11 @@ Process-wide and MQTT-broker settings used by every service. For multi-instance 
 
 ## Database
 
-MeshCore Hub runs on **PostgreSQL** — the only supported database backend since v0.19. The bundled container is part of the default `core` compose profile (zero-config), and the same `DATABASE_*` variables point the services at a managed/external instance or a shared cluster with schema-per-instance isolation. See [database.md](database.md) for the full reference: bundled container, production role/database provisioning, managed/external Postgres, and schema-per-instance isolation. Upgrading an old SQLite deployment? See [upgrading.md](upgrading.md) (v0.19 section).
+MeshCore Hub runs on **PostgreSQL** — the only supported database backend since v0.19. The bundled container is a development convenience (it joins the `core` compose profile via `docker-compose.dev.yml`, zero-config); in production the same `DATABASE_*` variables point the services at a managed/external instance or a shared cluster with schema-per-instance isolation. See [database.md](database.md) for the full reference: bundled container, production role/database provisioning, managed/external Postgres, and schema-per-instance isolation. Upgrading an old SQLite deployment? See [upgrading.md](upgrading.md) (v0.19 section).
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `DATABASE_HOST` | `postgres` | Postgres hostname (`postgres` = bundled container service name) |
+| `DATABASE_HOST` | `postgres` | Postgres hostname. `postgres` = the bundled container's service name (started with `core` only when using `docker-compose.dev.yml`; production points this at the shared/external instance) |
 | `DATABASE_PORT` | `5432` | Postgres port |
 | `DATABASE_NAME` | `meshcorehub` | Database name |
 | `DATABASE_SCHEMA` | `meshcorehub` | Schema (`search_path`). Set a distinct value per instance on a shared cluster |

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,22 +1,24 @@
 # Database
 
-MeshCore Hub runs on **PostgreSQL** — the only supported database backend since v0.19. The bundled container is part of the default `core` compose profile, so a standard `docker compose up` works with zero configuration; managed/external Postgres and multiple schema-isolated instances sharing one cluster are equally supported.
+MeshCore Hub runs on **PostgreSQL** — the only supported database backend since v0.19. A bundled container ships with the stack for development (it joins the `core` compose profile via `docker-compose.dev.yml`, so a standard dev `compose up` works with zero configuration); managed/external Postgres and multiple schema-isolated instances sharing one cluster are equally supported — and are the norm in production.
 
 > [!NOTE]
 > SQLite support (the pre-v0.14 default) was **removed in v0.19**. Existing SQLite deployments can migrate in place with the built-in `meshcore-hub db migrate-to-postgres` command — see [Upgrading from SQLite](#upgrading-from-sqlite) below and the [v0.19 upgrade guide](upgrading.md).
 
 ## Docker (bundled container)
 
-Postgres ships with the stack and starts with the `core` profile — no extra flags:
+Postgres ships with the stack. It is a **development convenience**: the base compose file only enables it for the `all` and standalone `postgres` profiles, and `docker-compose.dev.yml` unions it into `core` so the documented dev workflow needs no extra flags:
 
 ```bash
-# Default stack: bundled Postgres starts alongside the app services
+# Default dev stack: bundled Postgres starts alongside the app services
 docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile core up -d
 ```
 
+Production (`docker-compose.prod.yml`) deliberately leaves it out of `core` — the bundled container's `postgres` network alias would shadow a shared instance of the same name on the same network. Start it explicitly with `--profile postgres` (or `--profile all`) if you want the bundled database on a production host.
+
 The container derives `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` from `DATABASE_USER` / `DATABASE_PASSWORD` / `DATABASE_NAME`, and ships a **dev-only default password** (`meshcorehub`) so a default `up` initializes out of the box. **Production deployments must override `DATABASE_PASSWORD`** — the container is not published outside the compose network, but the default password is public knowledge (it is in the repo).
 
-The `migrate` service waits for Postgres to be healthy and runs `db upgrade` before `collector` and `api` start.
+The `migrate` service waits for Postgres to be healthy and runs `db upgrade` before `collector` and `api` start. That dependency is optional (`required: false`): when the bundled container is not enabled (production with an external database), `migrate` simply runs against `DATABASE_HOST` directly.
 
 ## Production provisioning (role and database)
 
@@ -33,7 +35,7 @@ The application **schema** and tables are created automatically by `db upgrade` 
 
 ## Managed or external Postgres
 
-To point Hub at an already-running Postgres (e.g. a managed cloud instance), set the `DATABASE_*` connection variables. The bundled container still starts with the `core` profile (it simply runs idle if the services point elsewhere); to skip it entirely, start a narrower profile set, e.g. `--profile collector --profile api`:
+To point Hub at an already-running Postgres (e.g. a managed cloud instance or a shared cluster on the same Docker network), set the `DATABASE_*` connection variables. With the production compose override the bundled container is not started at all — nothing extra to skip, and no risk of its `postgres` alias intercepting your `DATABASE_HOST`. (If you use the dev override against an external database, add the standalone `--profile postgres` only if you also want the bundled container running.)
 
 ```bash
 DATABASE_HOST=your-managed-postgres.example.com

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,6 +35,8 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile mqtt -
 docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile mqtt --profile core --profile observer up -d
 ```
 
+> **Database in production:** the bundled `postgres` container is **not** started by the `core` profile with `docker-compose.prod.yml` — its `postgres` network alias would shadow a shared instance of the same name on the same network. Point the `DATABASE_*` variables at your shared/managed Postgres (see [database.md](database.md)). If this host has no external database, opt in to the bundled container explicitly with `--profile postgres` and set a strong `DATABASE_PASSWORD`.
+
 Configure your reverse proxy to forward to the containers:
 
 | Service        | Container                     | Port | Path                             |
@@ -80,7 +82,7 @@ TRAEFIK_PRIORITY=20
 
 This ensures `beta.example.com` (priority 20) is matched before the production wildcard `*.example.com` (priority 10). For other services on the same network (e.g., an MQTT broker at `mqtt.example.com`), use an even higher priority (e.g., 30).
 
-> **Shared Postgres cluster:** the setup above runs each instance in its own directory with its own volumes (bundled Postgres container per instance). To instead run several instances (e.g. `prod` + `stg`) against **one** PostgreSQL cluster — isolated via a per-instance schema (`search_path`) — see [database.md](database.md#schema-per-instance-search_path).
+> **Shared Postgres cluster:** the setup above runs each instance in its own directory with its own volumes — add `--profile postgres` to each instance's `up` command for a bundled Postgres container per instance. To instead run several instances (e.g. `prod` + `stg`) against **one** PostgreSQL cluster — isolated via a per-instance schema (`search_path`) — see [database.md](database.md#schema-per-instance-search_path).
 
 ## Scaling the API
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,7 +10,7 @@ This guide covers upgrading from a previous MeshCore Hub release to the current 
 
 What changed:
 
-- **The bundled `postgres` container is part of the default `core` compose profile.** A plain `docker compose up` now starts PostgreSQL alongside the app services — still zero-config, including a working default password (`meshcorehub`, overridable via `DATABASE_PASSWORD`). **Production deployments must override `DATABASE_PASSWORD`** — the default is dev-only (the container is not published outside the compose network, but don't rely on that).
+- **The bundled `postgres` container is a development convenience — it joins the `core` compose profile only via `docker-compose.dev.yml`.** With the dev override, a plain `docker compose up` still starts PostgreSQL alongside the app services — zero-config, including a working default password (`meshcorehub`, overridable via `DATABASE_PASSWORD`). Production (`docker-compose.prod.yml`) deliberately does **not** start it with `core`/`migrate` profiles: its `postgres` network alias would shadow a shared instance of the same name on the same Docker network. Point `DATABASE_*` at your shared/managed instance, or opt in explicitly with `--profile postgres` (or `--profile all`). **Production deployments must override `DATABASE_PASSWORD`** — the default is dev-only (the container is not published outside the compose network, but don't rely on that).
 - **`DATABASE_BACKEND` is rejected, not ignored.** A leftover `DATABASE_BACKEND=sqlite` in your environment now fails at startup with a targeted error pointing at the migration command; `DATABASE_BACKEND=postgres` is accepted as a no-op. Remove the variable — the field itself is removed in v0.20.
 - **Missing database configuration fails fast.** With neither `DATABASE_URL` nor the `DATABASE_*` components (`DATABASE_HOST`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`) set, services refuse to start with an error naming the missing variables — no silent fallback.
 - **Tests run against PostgreSQL.** The backend suite requires a Postgres instance (`make test-db-up` starts a throwaway one; `TEST_POSTGRES_URL` points at your own). CI uses a `postgres:17` service container.
@@ -25,7 +25,7 @@ Downtime is required while writers are stopped; the source SQLite file is never 
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.dev.yml stop collector api
    ```
-3. **Bring up Postgres and create the schema** (on the v0.19 image; the bundled container starts with the `core` profile):
+3. **Bring up Postgres and create the schema** (on the v0.19 image; with the dev override the bundled container joins the `core` profile):
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres
    docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm migrate
@@ -43,6 +43,25 @@ Downtime is required while writers are stopped; the source SQLite file is never 
    ```
 
 > **Managed Postgres / non-superuser roles:** the migration disables foreign-key triggers during the copy via `session_replication_role = replica`, which requires a superuser. When the target role is not a superuser (typical for managed Postgres), the command automatically falls back to copying in parent-first order instead. Pass `--no-replication-role` to force the fallback explicitly.
+
+#### One-time cleanup: remove a previously started bundled Postgres (production)
+
+If you ran a v0.19 pre-release with `docker-compose.prod.yml` while pointing `DATABASE_HOST` at a shared/external instance, the bundled `postgres` container also started (it was wrongly part of the `core` profile) and may have been intercepting the `postgres` hostname. After upgrading:
+
+1. **Confirm which Postgres your stack uses** — if `DATABASE_HOST` points at a shared instance but a container named `${COMPOSE_PROJECT_NAME:-hub}-postgres` is running, it was shadowing the shared service:
+   ```bash
+   docker ps --filter name=hub-postgres
+   ```
+2. **Remove it once with a full `down`** (a plain `up` won't remove a service that no longer belongs to the active profile set; the `postgres_data` volume is retained by `down` without `-v`):
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile all down --remove-orphans
+   ```
+3. **Bring the stack back up** with your usual profiles — the bundled container no longer starts, and `DATABASE_HOST` resolves to your shared instance:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile core up -d
+   ```
+
+> If you intended to keep the bundled container as this deployment's database, start it explicitly with `--profile postgres` instead of relying on `core`.
 
 #### Scheduled for removal in v0.20
 


### PR DESCRIPTION
## Problem

Production deployments override `DATABASE_HOST` to point at a shared Postgres service (also named `postgres`) on the same Docker network. But `--profile core` with `docker-compose.prod.yml` also started the **bundled** postgres container, whose `postgres` network alias shadowed the shared instance — the live site silently connected to an empty local database instead of the shared one.

## Fix

The bundled postgres is now a **development convenience only**:

- `docker-compose.yml`: postgres profiles are `[all, postgres]` (`core` dropped); `migrate`'s postgres dependency is `required: false` (still health-gated when the container is active, skipped when profile-inactive).
- `docker-compose.dev.yml`: unions `core` back into the profile list (profiles merge across override files), so the documented dev workflow (`make up`, `--profile core`) is **unchanged**.
- `docker-compose.prod.yml`: documents that `core` never starts the bundled container here; opt in explicitly with `--profile postgres` (or `--profile all`) if a bundled production DB is wanted.
- Docs updated (`database.md`, `deployment.md`, `configuration.md`, README profile table, `.env.example`, AGENTS.md); `upgrading.md` gains a one-time cleanup runbook for deployments that already have a shadowing `hub-postgres` container (full `down --remove-orphans`, volume retained).

## Verification

```
# dev + mqtt core → postgres included (unchanged dev behavior)
$ docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile mqtt --profile core config --services
api collector migrate mqtt postgres web

# prod + core → no postgres
$ docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile core config --services
api collector migrate web

# prod opt-in still works
$ docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile core --profile postgres config --services
api collector migrate postgres web

# base-only (external DB, no override) up --dry-run: accepted, no postgres in plan
```

Compose profiles semantics (union across files; `depends_on.required: false` permits an inactive dependency) verified on Docker Compose v5.5.0. Running dev stack untouched. No Python/frontend code changes — no pytest/vitest impact.